### PR TITLE
Fix SonarQube's "string.IsNullOrEmpty should be used"

### DIFF
--- a/test/RulesEngine.UnitTest/BusinessRuleEngineTest.cs
+++ b/test/RulesEngine.UnitTest/BusinessRuleEngineTest.cs
@@ -750,7 +750,7 @@ namespace RulesEngine.UnitTest
         {
             public bool CheckExists(string str)
             {
-                if (str != null && str.Length > 0)
+                if (!string.IsNullOrEmpty(str))
                 {
                     return true;
                 }


### PR DESCRIPTION
Hello,

This pull request is _very simple_ and aims to reduce the technical debt. It specifically targets the "string.IsNullOrEmpty" should be used" [rule](https://rules.sonarsource.com/csharp/RSPEC-3256)  in SonarQube.