### PR TITLE
[158] Refresh compiled rules if stale.

### DIFF
--- a/src/RulesEngine/RulesCache.cs
+++ b/src/RulesEngine/RulesCache.cs
@@ -59,12 +59,12 @@ namespace RulesEngine
             _compileRules.AddOrUpdate(compiledRuleKey, (compiledRule, ticks), (k, v) => (compiledRule, ticks));
         }
 
-        /// <summary>Checks if the compiled rules is up-to-date.</summary>
+        /// <summary>Checks if the compiled rules are up-to-date.</summary>
         /// <param name="compiledRuleKey">The compiled rule key.</param>
         /// <param name="workflowName">The workflow name.</param>
          /// <returns>
         ///   <c>true</c> if [compiled rules] is newer than the [workflow rules]; otherwise, <c>false</c>.</returns>
-        public bool IsCompiledRulesUpToDate(string compiledRuleKey, string workflowName)
+        public bool AreCompiledRulesUpToDate(string compiledRuleKey, string workflowName)
         {
             if (_compileRules.TryGetValue(compiledRuleKey, out (IDictionary<string, RuleFunc<RuleResultTree>> rules, Int64 tick) compiledRulesObj))
             {

--- a/src/RulesEngine/RulesCache.cs
+++ b/src/RulesEngine/RulesCache.cs
@@ -13,10 +13,10 @@ namespace RulesEngine
     internal class RulesCache
     {
         /// <summary>The compile rules</summary>
-        private ConcurrentDictionary<string, IDictionary<string, RuleFunc<RuleResultTree>>> _compileRules = new ConcurrentDictionary<string, IDictionary<string, RuleFunc<RuleResultTree>>>();
+        private ConcurrentDictionary<string, (IDictionary<string, RuleFunc<RuleResultTree>>, Int64)> _compileRules = new ConcurrentDictionary<string,  (IDictionary<string, RuleFunc<RuleResultTree>>, Int64)>();
 
         /// <summary>The workflow rules</summary>
-        private ConcurrentDictionary<string, WorkflowRules> _workflowRules = new ConcurrentDictionary<string, WorkflowRules>();
+        private ConcurrentDictionary<string, (WorkflowRules, Int64)> _workflowRules = new ConcurrentDictionary<string, (WorkflowRules, Int64)>();
 
         /// <summary>Determines whether [contains workflow rules] [the specified workflow name].</summary>
         /// <param name="workflowName">Name of the workflow.</param>
@@ -46,7 +46,8 @@ namespace RulesEngine
         /// <param name="rules">The rules.</param>
         public void AddOrUpdateWorkflowRules(string workflowName, WorkflowRules rules)
         {
-            _workflowRules.AddOrUpdate(workflowName, rules, (k, v) => rules);
+            Int64 ticks = DateTime.UtcNow.Ticks;
+            _workflowRules.AddOrUpdate(workflowName, (rules, ticks), (k, v) => (rules, ticks));
         }
 
         /// <summary>Adds the or update compiled rule.</summary>
@@ -54,7 +55,26 @@ namespace RulesEngine
         /// <param name="compiledRule">The compiled rule.</param>
         public void AddOrUpdateCompiledRule(string compiledRuleKey, IDictionary<string, RuleFunc<RuleResultTree>> compiledRule)
         {
-            _compileRules.AddOrUpdate(compiledRuleKey, compiledRule, (k, v) => compiledRule);
+            Int64 ticks = DateTime.UtcNow.Ticks;
+            _compileRules.AddOrUpdate(compiledRuleKey, (compiledRule, ticks), (k, v) => (compiledRule, ticks));
+        }
+
+        /// <summary>Checks if the compiled rules is up-to-date.</summary>
+        /// <param name="compiledRuleKey">The compiled rule key.</param>
+        /// <param name="workflowName">The workflow name.</param>
+         /// <returns>
+        ///   <c>true</c> if [compiled rules] is newer than the [workflow rules]; otherwise, <c>false</c>.</returns>
+        public bool IsCompiledRulesUpToDate(string compiledRuleKey, string workflowName)
+        {
+            if (_compileRules.TryGetValue(compiledRuleKey, out (IDictionary<string, RuleFunc<RuleResultTree>> rules, Int64 tick) compiledRulesObj))
+            {
+                if (_workflowRules.TryGetValue(workflowName, out (WorkflowRules rules, Int64 tick) workflowRulesObj))
+                {
+                    return compiledRulesObj.tick >= workflowRulesObj.tick;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>Clears this instance.</summary>
@@ -70,10 +90,9 @@ namespace RulesEngine
         /// <exception cref="Exception">Could not find injected Workflow: {wfname}</exception>
         public WorkflowRules GetWorkFlowRules(string workflowName)
         {
-            _workflowRules.TryGetValue(workflowName, out var workflowRules);
-            if (workflowRules == null) return null;
-            else
+            if (_workflowRules.TryGetValue(workflowName, out (WorkflowRules rules, Int64 tick) workflowRulesObj))
             {
+                var workflowRules = workflowRulesObj.rules;
                 if (workflowRules.WorkflowRulesToInject?.Any() == true)
                 {
                     if (workflowRules.Rules == null)
@@ -94,6 +113,10 @@ namespace RulesEngine
 
                 return workflowRules;
             }
+            else
+            {
+                return null;
+            }
         }
 
 
@@ -102,19 +125,19 @@ namespace RulesEngine
         /// <returns>CompiledRule.</returns>
         public IDictionary<string, RuleFunc<RuleResultTree>> GetCompiledRules(string compiledRulesKey)
         {
-            return _compileRules[compiledRulesKey];
+            return _compileRules[compiledRulesKey].Item1;
         }
 
         /// <summary>Removes the specified workflow name.</summary>
         /// <param name="workflowName">Name of the workflow.</param>
         public void Remove(string workflowName)
         {
-            if (_workflowRules.TryRemove(workflowName, out WorkflowRules workflowObj))
+            if (_workflowRules.TryRemove(workflowName, out (WorkflowRules, Int64) workflowObj))
             {
                 var compiledKeysToRemove = _compileRules.Keys.Where(key => key.StartsWith(workflowName));
                 foreach (var key in compiledKeysToRemove)
                 {
-                    _compileRules.TryRemove(key, out IDictionary<string, RuleFunc<RuleResultTree>> val);
+                    _compileRules.TryRemove(key, out (IDictionary<string, RuleFunc<RuleResultTree>>, Int64) val);
                 }
             }
         }

--- a/src/RulesEngine/RulesEngine.cs
+++ b/src/RulesEngine/RulesEngine.cs
@@ -230,7 +230,7 @@ namespace RulesEngine
         private bool RegisterRule(string workflowName, params RuleParameter[] ruleParams)
         {
             var compileRulesKey = GetCompiledRulesKey(workflowName, ruleParams);
-            if (_rulesCache.ContainsCompiledRules(compileRulesKey))
+            if (_rulesCache.IsCompiledRulesUpToDate(compileRulesKey, workflowName))
             {
                 return true;
             }

--- a/src/RulesEngine/RulesEngine.cs
+++ b/src/RulesEngine/RulesEngine.cs
@@ -158,11 +158,11 @@ namespace RulesEngine
             try
             {
                 foreach (var workflowRule in workflowRules)
-                {
+                {                    
+                    var validator = new WorkflowRulesValidator();
+                    validator.ValidateAndThrow(workflowRule);
                     if (!_rulesCache.ContainsWorkflowRules(workflowRule.WorkflowName))
                     {
-                        var validator = new WorkflowRulesValidator();
-                        validator.ValidateAndThrow(workflowRule);
                         _rulesCache.AddOrUpdateWorkflowRules(workflowRule.WorkflowName, workflowRule);
                     }
                 }

--- a/src/RulesEngine/RulesEngine.cs
+++ b/src/RulesEngine/RulesEngine.cs
@@ -149,11 +149,37 @@ namespace RulesEngine
         #region Private Methods
 
         /// <summary>
-        /// Adds the workflow.
+        /// Adds the workflow if the workflow name is not already added. Ignores the rest.
         /// </summary>
         /// <param name="workflowRules">The workflow rules.</param>
         /// <exception cref="RuleValidationException"></exception>
         public void AddWorkflow(params WorkflowRules[] workflowRules)
+        {
+            try
+            {
+                foreach (var workflowRule in workflowRules)
+                {
+                    if (!_rulesCache.ContainsWorkflowRules(workflowRule.WorkflowName))
+                    {
+                        var validator = new WorkflowRulesValidator();
+                        validator.ValidateAndThrow(workflowRule);
+                        _rulesCache.AddOrUpdateWorkflowRules(workflowRule.WorkflowName, workflowRule);
+                    }
+                }
+            }
+            catch (ValidationException ex)
+            {
+                throw new RuleValidationException(ex.Message, ex.Errors);
+            }
+        }
+
+        /// <summary>
+        /// Adds new workflow rules if not previously added.
+        /// Or updates the rules for an existing workflow.
+        /// </summary>
+        /// <param name="workflowRules">The workflow rules.</param>
+        /// <exception cref="RuleValidationException"></exception>
+        public void AddOrUpdateWorkflow(params WorkflowRules[] workflowRules)
         {
             try
             {
@@ -230,7 +256,7 @@ namespace RulesEngine
         private bool RegisterRule(string workflowName, params RuleParameter[] ruleParams)
         {
             var compileRulesKey = GetCompiledRulesKey(workflowName, ruleParams);
-            if (_rulesCache.IsCompiledRulesUpToDate(compileRulesKey, workflowName))
+            if (_rulesCache.AreCompiledRulesUpToDate(compileRulesKey, workflowName))
             {
                 return true;
             }

--- a/test/RulesEngine.UnitTest/BusinessRuleEngineTest.cs
+++ b/test/RulesEngine.UnitTest/BusinessRuleEngineTest.cs
@@ -86,12 +86,12 @@ namespace RulesEngine.UnitTest
             List<RuleResultTree> result2 = await re.ExecuteAllRulesAsync("inputWorkflow", input1, input2, input3);
             Assert.NotNull(result2);
             Assert.IsType<List<RuleResultTree>>(result2);
-            Assert.Contains(result1, c => c.IsSuccess);
+            Assert.Contains(result2, c => c.IsSuccess);
 
             // New execution should have same result than previous execution as workflow rules are not updated.
-            var expected = result1.Select(c => new { c.Rule.RuleName, c.IsSuccess });
-            var actual = result2.Select(c => new { c.Rule.RuleName, c.IsSuccess });
-            Assert.Equal(expected, actual);
+            var previousResults = result1.Select(c => new { c.Rule.RuleName, c.IsSuccess });
+            var newResults = result2.Select(c => new { c.Rule.RuleName, c.IsSuccess });
+            Assert.Equal(previousResults, newResults);
         }
 
         [Theory]
@@ -121,9 +121,9 @@ namespace RulesEngine.UnitTest
             Assert.DoesNotContain(result2, c => c.IsSuccess);
 
             // New execution should have different result than previous execution.
-            var expected = result1.Select(c => new { c.Rule.RuleName, c.IsSuccess });
-            var actual = result2.Select(c => new { c.Rule.RuleName, c.IsSuccess });
-            Assert.NotEqual(expected, actual);
+            var previousResults = result1.Select(c => new { c.Rule.RuleName, c.IsSuccess });
+            var newResults = result2.Select(c => new { c.Rule.RuleName, c.IsSuccess });
+            Assert.NotEqual(previousResults, newResults);
         }
 
         [Theory]


### PR DESCRIPTION
Solves #158.

### Changes

1. Attach timestamp in `_workflowRules` and `_compileRules` in `RulesCache.cs` to determine if the compile rule is stale.
2. Fix the bug for not refreshing compiled rules if workflow rules have been added.
3. Introduce a new method `AddOrUpdateWorkflow` to add rules for a new workflow or update rules for existing workflow.
4. Update `AddWorkflow` to add the workflow rules only if the workflow is new.