### PR TITLE
error code added to rule model

### DIFF
--- a/src/RulesEngine/Models/Rule.cs
+++ b/src/RulesEngine/Models/Rule.cs
@@ -29,6 +29,7 @@ namespace RulesEngine.Models
         public Dictionary<string, object> Properties { get; set; }
         public string Operator { get; set; }
         public string ErrorMessage { get; set; }
+        public string ErrorCode { get; set; }
 
         /// <summary>
         /// Gets or sets whether the rule is enabled.


### PR DESCRIPTION
Error code can also be used when the rule returns with the message.