### PR TITLE
Entity Framework demonstration

### DIFF
--- a/RulesEngine.sln
+++ b/RulesEngine.sln
@@ -26,6 +26,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RulesEngineBenchmark", "ben
 		{CD4DFE6A-083B-478E-8377-77F474833E30} = {CD4DFE6A-083B-478E-8377-77F474833E30}
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DemoApp.EFDataExample", "demo\DemoApp.EFDataExample\DemoApp.EFDataExample.csproj", "{E376D3E6-6890-4C09-9EA0-3EFD9C1E036D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -48,6 +50,10 @@ Global
 		{C058809F-C720-4EFC-925D-A486627B238B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C058809F-C720-4EFC-925D-A486627B238B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C058809F-C720-4EFC-925D-A486627B238B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E376D3E6-6890-4C09-9EA0-3EFD9C1E036D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E376D3E6-6890-4C09-9EA0-3EFD9C1E036D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E376D3E6-6890-4C09-9EA0-3EFD9C1E036D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E376D3E6-6890-4C09-9EA0-3EFD9C1E036D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/demo/DemoApp.EFDataExample/DemoApp.EFDataExample.csproj
+++ b/demo/DemoApp.EFDataExample/DemoApp.EFDataExample.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>DemoApp.EFDataExample</RootNamespace>
+    <AssemblyName>DemoApp.EFDataExample</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\RulesEngine\RulesEngine.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/demo/DemoApp.EFDataExample/RulesEngineDemoContext.cs
+++ b/demo/DemoApp.EFDataExample/RulesEngineDemoContext.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using RulesEngine.Models;
 
-namespace DemoApp
+namespace DemoApp.EFDataExample
 {
     public class RulesEngineDemoContext : DbContext
     {

--- a/demo/DemoApp/DemoApp.csproj
+++ b/demo/DemoApp/DemoApp.csproj
@@ -7,10 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <ProjectReference Include="../../src/RulesEngine/RulesEngine.csproj" />
+    <ProjectReference Include="..\DemoApp.EFDataExample\DemoApp.EFDataExample.csproj" />
   </ItemGroup>
   
   <ItemGroup>

--- a/demo/DemoApp/DemoApp.csproj
+++ b/demo/DemoApp/DemoApp.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <ProjectReference Include="../../src/RulesEngine/RulesEngine.csproj" />
   </ItemGroup>

--- a/demo/DemoApp/EFDemo.cs
+++ b/demo/DemoApp/EFDemo.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 //  Licensed under the MIT License.
 
-using Microsoft.EntityFrameworkCore;
+using DemoApp.EFDataExample;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using RulesEngine.Models;
@@ -11,6 +11,7 @@ using System.Dynamic;
 using System.IO;
 using System.Linq;
 using static RulesEngine.Extensions.ListofRuleResultTreeExtension;
+using Microsoft.EntityFrameworkCore;
 
 namespace DemoApp
 {

--- a/demo/DemoApp/EFDemo.cs
+++ b/demo/DemoApp/EFDemo.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation.
+//  Licensed under the MIT License.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using RulesEngine.Models;
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.IO;
+using System.Linq;
+using static RulesEngine.Extensions.ListofRuleResultTreeExtension;
+
+namespace DemoApp
+{
+  public class EFDemo
+  {
+    public void Run()
+    {
+      Console.WriteLine($"Running {nameof(EFDemo)}....");
+      var basicInfo = "{\"name\": \"hello\",\"email\": \"abcy@xyz.com\",\"creditHistory\": \"good\",\"country\": \"canada\",\"loyalityFactor\": 3,\"totalPurchasesToDate\": 10000}";
+      var orderInfo = "{\"totalOrders\": 5,\"recurringItems\": 2}";
+      var telemetryInfo = "{\"noOfVisitsPerMonth\": 10,\"percentageOfBuyingToVisit\": 15}";
+
+      var converter = new ExpandoObjectConverter();
+
+      dynamic input1 = JsonConvert.DeserializeObject<ExpandoObject>(basicInfo, converter);
+      dynamic input2 = JsonConvert.DeserializeObject<ExpandoObject>(orderInfo, converter);
+      dynamic input3 = JsonConvert.DeserializeObject<ExpandoObject>(telemetryInfo, converter);
+
+      var inputs = new dynamic[]
+          {
+                    input1,
+                    input2,
+                    input3
+          };
+
+      var files = Directory.GetFiles(Directory.GetCurrentDirectory(), "Discount.json", SearchOption.AllDirectories);
+      if (files == null || files.Length == 0)
+        throw new Exception("Rules not found.");
+
+      var fileData = File.ReadAllText(files[0]);
+      var workflowRules = JsonConvert.DeserializeObject<List<WorkflowRules>>(fileData);
+
+      RulesEngineDemoContext db = new RulesEngineDemoContext();
+      if (db.Database.EnsureCreated())
+      {
+        db.WorkflowRules.AddRange(workflowRules);
+        db.SaveChanges();
+      }
+
+      var bre = new RulesEngine.RulesEngine(db.WorkflowRules.ToArray(), null);
+
+      string discountOffered = "No discount offered.";
+
+      List<RuleResultTree> resultList = bre.ExecuteAllRulesAsync("Discount", inputs).Result;
+
+      resultList.OnSuccess((eventName) => {
+        discountOffered = $"Discount offered is {eventName} % over MRP.";
+      });
+
+      resultList.OnFail(() => {
+        discountOffered = "The user is not eligible for any discount.";
+      });
+
+      Console.WriteLine(discountOffered);
+    }
+  }
+}

--- a/demo/DemoApp/Program.cs
+++ b/demo/DemoApp/Program.cs
@@ -9,6 +9,7 @@ namespace DemoApp
         {
             new BasicDemo().Run();
             new NestedInputDemo().Run();
+            new EFDemo().Run();
         }
     }
 }

--- a/demo/DemoApp/RulesEngineDemoContext.cs
+++ b/demo/DemoApp/RulesEngineDemoContext.cs
@@ -45,36 +45,7 @@ namespace DemoApp
 
             modelBuilder.Entity<WorkflowRules>(entity => {
                 entity.HasKey(k => k.WorkflowName); 
-           //     entity.Property(b => b.Rules)
-           //    .HasConversion(
-           //     v => JsonConvert.SerializeObject(v),
-           //     v => JsonConvert.DeserializeObject<IEnumerable<Rule>>(v.Length == 0 ? null : v),
-           //      new ValueComparer<IEnumerable<Rule>>(
-           //(c1, c2) => c1.SequenceEqual(c2),
-           //c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
-           //c => (IEnumerable<Rule>)c.AsEnumerable()));
-               
-                // entity.Property(b => b.Rules)
-                //.HasConversion(
-                //   v => v,
-                //   v => ((List<Rule>)v).Count == 0 ? null : v);
             });
-
-
-
-
-            //modelBuilder.Entity<Rule>()
-            //  .Property(b => b.Actions.OnSuccess.Context)
-            //  .HasConversion(
-            //     v => JsonConvert.SerializeObject(v),
-            //     v => JsonConvert.DeserializeObject<Dictionary<string, object>>(v));
-
-            //modelBuilder.Entity<Rule>()
-            // .Property(b => b.Actions.OnFailure.Context)
-            // .HasConversion(
-            //    v => JsonConvert.SerializeObject(v),
-            //    v => JsonConvert.DeserializeObject<Dictionary<string, object>>(v));
-
 
             modelBuilder.Entity<RuleActions>(entity => {
                 entity.HasNoKey();
@@ -82,55 +53,30 @@ namespace DemoApp
                 entity.HasOne(o => o.OnFailure).WithMany();
             });
 
-
             modelBuilder.Entity<Rule>(entity => {
                 entity.HasKey(k => k.RuleName);
-                //entity.Property(p => p.Rules)
-                //    .HasConversion(
-                //    r => r, 
-                //    r => r);
 
+                //EF translates an empty IEnumerable to a new Object with Count of 0 not a null (like JSON)
+                //Using HasConversion has nesting issues
                 // Message=The property 'Rule.Rules' is of type 'IEnumerable<Rule>' which is not supported by the current database provider. Either change the property CLR type, or ignore the property using the '[NotMapped]' attribute or by using 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.
+                //
                 //entity.Property(b => b.Rules)
                 //.HasConversion(
                 //    v => v,
                 //    v => v.Count() == 0 ? null : v);
-                //     v => JsonConvert.SerializeObject(v),
-                //     v => JsonConvert.DeserializeObject<IEnumerable<Rule>>(v.Length == 0 ? null : v),
-                //      new ValueComparer<IEnumerable<Rule>>(
-                //(c1, c2) => c1.SequenceEqual(c2),
-                //c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
-                //c => (IEnumerable<Rule>)c.AsEnumerable()));
-
+               
                 entity.Property(b => b.Properties)
                 .HasConversion(
                    v => JsonConvert.SerializeObject(v),
                    v => JsonConvert.DeserializeObject<Dictionary<string, object>>(v));
                 entity.Ignore(e => e.Actions);
-                //entity.HasNoKey();
-                //entity.HasOne(o => o.Actions).WithMany().HasForeignKey(k => k.RuleName);
             });
-
-
-            //modelBuilder.Entity<ActionInfo>(entity => {
-            //    entity.HasNoKey();
-            //});
-
-            //modelBuilder.Entity<RuleActions>()
-            //.Property(p => p.Id).ValueGeneratedOnAdd();
-
-            //modelBuilder.Entity<RuleActions>()
-            //.HasKey(k => k.Id);
-
-            //modelBuilder.Entity<RuleActions>()
-            //.HasOne(o => o.OnFailure).WithOne(o => o.Actions);//.HasForeignKey("Rule");
 
             modelBuilder.Entity<WorkflowRules>()
                .Ignore(b => b.WorkflowRulesToInject);
 
             modelBuilder.Entity<Rule>()
               .Ignore(b => b.WorkflowRulesToInject);
-
         }
     }
 

--- a/demo/DemoApp/RulesEngineDemoContext.cs
+++ b/demo/DemoApp/RulesEngineDemoContext.cs
@@ -44,11 +44,20 @@ namespace DemoApp
               .HasKey(k => k.Name);
 
             modelBuilder.Entity<WorkflowRules>(entity => {
-                entity.HasKey(k => k.WorkflowName);
-               // entity.Property(b => b.Rules)
-               //.HasConversion(
-               //   v => v,
-               //   v => ((List<Rule>)v).Count == 0 ? null : v);
+                entity.HasKey(k => k.WorkflowName); 
+           //     entity.Property(b => b.Rules)
+           //    .HasConversion(
+           //     v => JsonConvert.SerializeObject(v),
+           //     v => JsonConvert.DeserializeObject<IEnumerable<Rule>>(v.Length == 0 ? null : v),
+           //      new ValueComparer<IEnumerable<Rule>>(
+           //(c1, c2) => c1.SequenceEqual(c2),
+           //c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
+           //c => (IEnumerable<Rule>)c.AsEnumerable()));
+               
+                // entity.Property(b => b.Rules)
+                //.HasConversion(
+                //   v => v,
+                //   v => ((List<Rule>)v).Count == 0 ? null : v);
             });
 
 
@@ -80,10 +89,18 @@ namespace DemoApp
                 //    .HasConversion(
                 //    r => r, 
                 //    r => r);
+
+                // Message=The property 'Rule.Rules' is of type 'IEnumerable<Rule>' which is not supported by the current database provider. Either change the property CLR type, or ignore the property using the '[NotMapped]' attribute or by using 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.
                 //entity.Property(b => b.Rules)
                 //.HasConversion(
-                // v => v,
-                // v => ((List<Rule>)v).Count == 0 ? null : v);
+                //    v => v,
+                //    v => v.Count() == 0 ? null : v);
+                //     v => JsonConvert.SerializeObject(v),
+                //     v => JsonConvert.DeserializeObject<IEnumerable<Rule>>(v.Length == 0 ? null : v),
+                //      new ValueComparer<IEnumerable<Rule>>(
+                //(c1, c2) => c1.SequenceEqual(c2),
+                //c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
+                //c => (IEnumerable<Rule>)c.AsEnumerable()));
 
                 entity.Property(b => b.Properties)
                 .HasConversion(

--- a/demo/DemoApp/RulesEngineDemoContext.cs
+++ b/demo/DemoApp/RulesEngineDemoContext.cs
@@ -7,90 +7,114 @@ using RulesEngine.Models;
 
 namespace DemoApp
 {
-  public class RulesEngineDemoContext : DbContext
-  {
-    public DbSet<WorkflowRules> WorkflowRules { get; set; }
-    public DbSet<ActionInfo> ActionInfos { get; set; }
-
-    public DbSet<RuleActions> RuleActions { get; set; }
-    public DbSet<Rule> Rules { get; set; }
-    public DbSet<ScopedParam> ScopedParams { get; set; }
-
-    public string DbPath { get; private set; }
-
-    public RulesEngineDemoContext()
+    public class RulesEngineDemoContext : DbContext
     {
-      var folder = Environment.SpecialFolder.LocalApplicationData;
-      var path = Environment.GetFolderPath(folder);
-      DbPath = $"{path}{System.IO.Path.DirectorySeparatorChar}RulesEngineDemo.db";
+        public DbSet<WorkflowRules> WorkflowRules { get; set; }
+        public DbSet<ActionInfo> ActionInfos { get; set; }
+
+        public DbSet<RuleActions> RuleActions { get; set; }
+        public DbSet<Rule> Rules { get; set; }
+        public DbSet<ScopedParam> ScopedParams { get; set; }
+
+        public string DbPath { get; private set; }
+
+        public RulesEngineDemoContext()
+        {
+            var folder = Environment.SpecialFolder.LocalApplicationData;
+            var path = Environment.GetFolderPath(folder);
+            DbPath = $"{path}{System.IO.Path.DirectorySeparatorChar}RulesEngineDemo.db";
+        }
+        protected override void OnConfiguring(DbContextOptionsBuilder options)
+          => options.UseSqlite($"Data Source={DbPath}");
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<ActionInfo>()
+                .Property(b => b.Context)
+                .HasConversion(
+                   v => JsonConvert.SerializeObject(v),
+                   v => JsonConvert.DeserializeObject<Dictionary<string, object>>(v));
+
+            modelBuilder.Entity<ActionInfo>()
+              .HasKey(k => k.Name);
+
+            modelBuilder.Entity<ScopedParam>()
+              .HasKey(k => k.Name);
+
+            modelBuilder.Entity<WorkflowRules>(entity => {
+                entity.HasKey(k => k.WorkflowName);
+               // entity.Property(b => b.Rules)
+               //.HasConversion(
+               //   v => v,
+               //   v => ((List<Rule>)v).Count == 0 ? null : v);
+            });
+
+
+
+
+            //modelBuilder.Entity<Rule>()
+            //  .Property(b => b.Actions.OnSuccess.Context)
+            //  .HasConversion(
+            //     v => JsonConvert.SerializeObject(v),
+            //     v => JsonConvert.DeserializeObject<Dictionary<string, object>>(v));
+
+            //modelBuilder.Entity<Rule>()
+            // .Property(b => b.Actions.OnFailure.Context)
+            // .HasConversion(
+            //    v => JsonConvert.SerializeObject(v),
+            //    v => JsonConvert.DeserializeObject<Dictionary<string, object>>(v));
+
+
+            modelBuilder.Entity<RuleActions>(entity => {
+                entity.HasNoKey();
+                entity.HasOne(o => o.OnSuccess).WithMany();
+                entity.HasOne(o => o.OnFailure).WithMany();
+            });
+
+
+            modelBuilder.Entity<Rule>(entity => {
+                entity.HasKey(k => k.RuleName);
+                //entity.Property(p => p.Rules)
+                //    .HasConversion(
+                //    r => r, 
+                //    r => r);
+                //entity.Property(b => b.Rules)
+                //.HasConversion(
+                // v => v,
+                // v => ((List<Rule>)v).Count == 0 ? null : v);
+
+                entity.Property(b => b.Properties)
+                .HasConversion(
+                   v => JsonConvert.SerializeObject(v),
+                   v => JsonConvert.DeserializeObject<Dictionary<string, object>>(v));
+                entity.Ignore(e => e.Actions);
+                //entity.HasNoKey();
+                //entity.HasOne(o => o.Actions).WithMany().HasForeignKey(k => k.RuleName);
+            });
+
+
+            //modelBuilder.Entity<ActionInfo>(entity => {
+            //    entity.HasNoKey();
+            //});
+
+            //modelBuilder.Entity<RuleActions>()
+            //.Property(p => p.Id).ValueGeneratedOnAdd();
+
+            //modelBuilder.Entity<RuleActions>()
+            //.HasKey(k => k.Id);
+
+            //modelBuilder.Entity<RuleActions>()
+            //.HasOne(o => o.OnFailure).WithOne(o => o.Actions);//.HasForeignKey("Rule");
+
+            modelBuilder.Entity<WorkflowRules>()
+               .Ignore(b => b.WorkflowRulesToInject);
+
+            modelBuilder.Entity<Rule>()
+              .Ignore(b => b.WorkflowRulesToInject);
+
+        }
     }
-    protected override void OnConfiguring(DbContextOptionsBuilder options)
-      => options.UseSqlite($"Data Source={DbPath}");
-
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-      base.OnModelCreating(modelBuilder);
-
-      modelBuilder.Entity<ActionInfo>()
-          .Property(b => b.Context)
-          .HasConversion(
-             v => JsonConvert.SerializeObject(v),
-             v => JsonConvert.DeserializeObject<Dictionary<string, object>>(v));
-
-      modelBuilder.Entity<ActionInfo>()
-        .HasKey(k => k.Name);
-
-      modelBuilder.Entity<ScopedParam>()
-        .HasKey(k => k.Name);
-
-      modelBuilder.Entity<WorkflowRules>()
-        .HasKey(k => k.WorkflowName);
-
-      modelBuilder.Entity<Rule>()
-          .Property(b => b.Properties)
-          .HasConversion(
-             v => JsonConvert.SerializeObject(v),
-             v => JsonConvert.DeserializeObject<Dictionary<string, object>>(v));
-
-      //modelBuilder.Entity<Rule>()
-      //  .Property(b => b.Actions.OnSuccess.Context)
-      //  .HasConversion(
-      //     v => JsonConvert.SerializeObject(v),
-      //     v => JsonConvert.DeserializeObject<Dictionary<string, object>>(v));
-
-      //modelBuilder.Entity<Rule>()
-      // .Property(b => b.Actions.OnFailure.Context)
-      // .HasConversion(
-      //    v => JsonConvert.SerializeObject(v),
-      //    v => JsonConvert.DeserializeObject<Dictionary<string, object>>(v));
-
-
-      modelBuilder.Entity<Rule>(entity => {
-        entity.HasKey(k => k.RuleName);
-        entity.HasOne(o => o.Actions).WithOne();
-      });
-
-      modelBuilder.Entity<RuleActions>(entity => {
-        entity.HasNoKey();
-        //entity.HasOne(o => o.OnSuccess).WithOne();
-      });
-
-      //modelBuilder.Entity<RuleActions>()
-      //.Property(p => p.Id).ValueGeneratedOnAdd();
-
-      //modelBuilder.Entity<RuleActions>()
-      //.HasKey(k => k.Id);
-
-      //modelBuilder.Entity<RuleActions>()
-      //.HasOne(o => o.OnFailure).WithOne(o => o.Actions);//.HasForeignKey("Rule");
-
-      modelBuilder.Entity<WorkflowRules>()
-         .Ignore(b => b.WorkflowRulesToInject);
-
-      modelBuilder.Entity<Rule>()
-        .Ignore(b => b.WorkflowRulesToInject);
-
-    }
-  }
 
 }

--- a/demo/DemoApp/RulesEngineDemoContext.cs
+++ b/demo/DemoApp/RulesEngineDemoContext.cs
@@ -55,15 +55,6 @@ namespace DemoApp
 
             modelBuilder.Entity<Rule>(entity => {
                 entity.HasKey(k => k.RuleName);
-
-                //EF translates an empty IEnumerable to a new Object with Count of 0 not a null (like JSON)
-                //Using HasConversion has nesting issues
-                // Message=The property 'Rule.Rules' is of type 'IEnumerable<Rule>' which is not supported by the current database provider. Either change the property CLR type, or ignore the property using the '[NotMapped]' attribute or by using 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.
-                //
-                //entity.Property(b => b.Rules)
-                //.HasConversion(
-                //    v => v,
-                //    v => v.Count() == 0 ? null : v);
                
                 entity.Property(b => b.Properties)
                 .HasConversion(

--- a/demo/DemoApp/RulesEngineDemoContext.cs
+++ b/demo/DemoApp/RulesEngineDemoContext.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using RulesEngine.Models;
+
+namespace DemoApp
+{
+  public class RulesEngineDemoContext : DbContext
+  {
+    public DbSet<WorkflowRules> WorkflowRules { get; set; }
+    public DbSet<ActionInfo> ActionInfos { get; set; }
+
+    public DbSet<RuleActions> RuleActions { get; set; }
+    public DbSet<Rule> Rules { get; set; }
+    public DbSet<ScopedParam> ScopedParams { get; set; }
+
+    public string DbPath { get; private set; }
+
+    public RulesEngineDemoContext()
+    {
+      var folder = Environment.SpecialFolder.LocalApplicationData;
+      var path = Environment.GetFolderPath(folder);
+      DbPath = $"{path}{System.IO.Path.DirectorySeparatorChar}RulesEngineDemo.db";
+    }
+    protected override void OnConfiguring(DbContextOptionsBuilder options)
+      => options.UseSqlite($"Data Source={DbPath}");
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+      base.OnModelCreating(modelBuilder);
+
+      modelBuilder.Entity<ActionInfo>()
+          .Property(b => b.Context)
+          .HasConversion(
+             v => JsonConvert.SerializeObject(v),
+             v => JsonConvert.DeserializeObject<Dictionary<string, object>>(v));
+
+      modelBuilder.Entity<ActionInfo>()
+        .HasKey(k => k.Name);
+
+      modelBuilder.Entity<ScopedParam>()
+        .HasKey(k => k.Name);
+
+      modelBuilder.Entity<WorkflowRules>()
+        .HasKey(k => k.WorkflowName);
+
+      modelBuilder.Entity<Rule>()
+          .Property(b => b.Properties)
+          .HasConversion(
+             v => JsonConvert.SerializeObject(v),
+             v => JsonConvert.DeserializeObject<Dictionary<string, object>>(v));
+
+      //modelBuilder.Entity<Rule>()
+      //  .Property(b => b.Actions.OnSuccess.Context)
+      //  .HasConversion(
+      //     v => JsonConvert.SerializeObject(v),
+      //     v => JsonConvert.DeserializeObject<Dictionary<string, object>>(v));
+
+      //modelBuilder.Entity<Rule>()
+      // .Property(b => b.Actions.OnFailure.Context)
+      // .HasConversion(
+      //    v => JsonConvert.SerializeObject(v),
+      //    v => JsonConvert.DeserializeObject<Dictionary<string, object>>(v));
+
+
+      modelBuilder.Entity<Rule>(entity => {
+        entity.HasKey(k => k.RuleName);
+        entity.HasOne(o => o.Actions).WithOne();
+      });
+
+      modelBuilder.Entity<RuleActions>(entity => {
+        entity.HasNoKey();
+        //entity.HasOne(o => o.OnSuccess).WithOne();
+      });
+
+      //modelBuilder.Entity<RuleActions>()
+      //.Property(p => p.Id).ValueGeneratedOnAdd();
+
+      //modelBuilder.Entity<RuleActions>()
+      //.HasKey(k => k.Id);
+
+      //modelBuilder.Entity<RuleActions>()
+      //.HasOne(o => o.OnFailure).WithOne(o => o.Actions);//.HasForeignKey("Rule");
+
+      modelBuilder.Entity<WorkflowRules>()
+         .Ignore(b => b.WorkflowRulesToInject);
+
+      modelBuilder.Entity<Rule>()
+        .Ignore(b => b.WorkflowRulesToInject);
+
+    }
+  }
+
+}

--- a/src/RulesEngine/Validators/RuleValidator.cs
+++ b/src/RulesEngine/Validators/RuleValidator.cs
@@ -37,7 +37,7 @@ namespace RulesEngine.Validators
 
         private void RegisterExpressionTypeRules()
         {
-            When(c => c.Operator == null && (c.Rules != null ? c.Rules.Count() != 0 : true) && c.RuleExpressionType == RuleExpressionType.LambdaExpression, () => {
+            When(c => c.Operator == null && (c.Rules == null ? true : c.Rules.Count() != 0) && c.RuleExpressionType == RuleExpressionType.LambdaExpression, () => {
                 RuleFor(c => c.Expression).NotEmpty().WithMessage(Constants.LAMBDA_EXPRESSION_EXPRESSION_NULL_ERRMSG);
                 RuleFor(c => c.Rules).Null().WithMessage(Constants.LAMBDA_EXPRESSION_RULES_ERRMSG);
             });

--- a/src/RulesEngine/Validators/RuleValidator.cs
+++ b/src/RulesEngine/Validators/RuleValidator.cs
@@ -37,7 +37,7 @@ namespace RulesEngine.Validators
 
         private void RegisterExpressionTypeRules()
         {
-            When(c => c.Operator == null && c.RuleExpressionType == RuleExpressionType.LambdaExpression, () => {
+            When(c => c.Operator == null && (c.Rules != null ? c.Rules.Count() != 0 : true) && c.RuleExpressionType == RuleExpressionType.LambdaExpression, () => {
                 RuleFor(c => c.Expression).NotEmpty().WithMessage(Constants.LAMBDA_EXPRESSION_EXPRESSION_NULL_ERRMSG);
                 RuleFor(c => c.Rules).Null().WithMessage(Constants.LAMBDA_EXPRESSION_RULES_ERRMSG);
             });

--- a/src/RulesEngine/Validators/RuleValidator.cs
+++ b/src/RulesEngine/Validators/RuleValidator.cs
@@ -37,9 +37,9 @@ namespace RulesEngine.Validators
 
         private void RegisterExpressionTypeRules()
         {
-            When(c => c.Operator == null && (c.Rules == null ? true : c.Rules.Count() != 0) && c.RuleExpressionType == RuleExpressionType.LambdaExpression, () => {
+            When(c => c.Operator == null && c.RuleExpressionType == RuleExpressionType.LambdaExpression, () => {
                 RuleFor(c => c.Expression).NotEmpty().WithMessage(Constants.LAMBDA_EXPRESSION_EXPRESSION_NULL_ERRMSG);
-                RuleFor(c => c.Rules).Null().WithMessage(Constants.LAMBDA_EXPRESSION_RULES_ERRMSG);
+                RuleFor(c => c.Rules).Empty().WithMessage(Constants.LAMBDA_EXPRESSION_RULES_ERRMSG);
             });
         }
 

--- a/test/RulesEngine.UnitTest/EmptyRulesTest.cs
+++ b/test/RulesEngine.UnitTest/EmptyRulesTest.cs
@@ -1,0 +1,156 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+using RulesEngine.Models;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Dynamic;
+using System.Linq;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RulesEngine.UnitTest
+{
+    [ExcludeFromCodeCoverage]
+    public class EmptyRulesTest
+    {
+        [Fact]
+        private async Task EmptyRules_ReturnsExepectedResults()
+        {
+            var workflows = GetEmptyWorkflows();
+            var reSettings = new ReSettings { };
+            RulesEngine rulesEngine = new RulesEngine();
+
+            Func<Task> action = () => {
+                new RulesEngine(workflows, reSettings: reSettings);
+                return Task.CompletedTask;
+            };
+
+            Exception ex = await Assert.ThrowsAsync<Exceptions.RuleValidationException>(action);
+
+            Assert.Contains("Atleast one of Rules or WorkflowRulesToInject must be not empty", ex.Message);
+        }
+        [Fact]
+        private async Task NestedRulesWithEmptyNestedActions_ReturnsExepectedResults()
+        {
+            var workflows = GetEmptyNestedWorkflows();
+            var reSettings = new ReSettings { };
+            RulesEngine rulesEngine = new RulesEngine();
+
+            Func<Task> action = () => {
+                new RulesEngine(workflows, reSettings: reSettings);
+                return Task.CompletedTask;
+            };
+
+            Exception ex = await Assert.ThrowsAsync<Exceptions.RuleValidationException>(action);
+
+            Assert.Contains("Atleast one of Rules or WorkflowRulesToInject must be not empty", ex.Message);
+        }
+
+        private WorkflowRules[] GetEmptyWorkflows()
+        {
+            return new[] {
+                new WorkflowRules {
+                    WorkflowName = "EmptyRulesTest",
+                    Rules = new Rule[] {
+                    }
+                }
+            };
+        }
+
+        private WorkflowRules[] GetEmptyNestedWorkflows()
+        {
+            return new[] {
+                new WorkflowRules {
+                    WorkflowName = "EmptyNestedRulesTest",
+                    Rules = new Rule[] {
+                        new Rule {
+                            RuleName = "AndRuleTrueFalse",
+                            Operator = "And",
+                            Rules = new Rule[] {
+                                new Rule{
+                                    RuleName = "trueRule1",
+                                    Expression = "input1.TrueValue == true",
+                                },
+                                new Rule {
+                                    RuleName = "falseRule1",
+                                    Expression = "input1.TrueValue == false"
+                                }
+
+                            }
+                        },
+                        new Rule {
+                            RuleName = "OrRuleTrueFalse",
+                            Operator = "Or",
+                            Rules = new Rule[] {
+                                new Rule{
+                                    RuleName = "trueRule2",
+                                    Expression = "input1.TrueValue == true",
+                                },
+                                new Rule {
+                                    RuleName = "falseRule2",
+                                    Expression = "input1.TrueValue == false"
+                                }
+
+                            }
+                        },
+                        new Rule {
+                            RuleName = "AndRuleFalseTrue",
+                            Operator = "And",
+                            Rules = new Rule[] {
+                                new Rule{
+                                    RuleName = "trueRule3",
+                                    Expression = "input1.TrueValue == false",
+                                },
+                                new Rule {
+                                    RuleName = "falseRule4",
+                                    Expression = "input1.TrueValue == true"
+                                }
+
+                            }
+                        },
+                         new Rule {
+                            RuleName = "OrRuleFalseTrue",
+                            Operator = "Or",
+                            Rules = new Rule[] {
+                                new Rule{
+                                    RuleName = "trueRule3",
+                                    Expression = "input1.TrueValue == false",
+                                },
+                                new Rule {
+                                    RuleName = "falseRule4",
+                                    Expression = "input1.TrueValue == true"
+                                }
+
+                            }
+                         }
+                    }
+                },
+                new WorkflowRules {
+                    WorkflowName = "EmptyNestedRulesActionsTest",
+                    Rules = new Rule[] {
+                        new Rule {
+                            RuleName = "AndRuleTrueFalse",
+                            Operator = "And",
+                            Rules = new Rule[] {
+
+                            },
+                            Actions =  new RuleActions {
+                                        OnFailure = new ActionInfo{
+                                            Name = "OutputExpression",
+                                            Context = new Dictionary<string, object> {
+                                                { "Expression", "input1.TrueValue" }
+                                            }
+                                        }
+                                    }
+                        }
+                    }
+                }
+
+            };
+        }
+    }
+}


### PR DESCRIPTION
This PR is intended to introduce persistence of Rules Engine workflows using Entity Framework integrated at the table and column level. This will facilitate external tools (e.g. UI) to define workflow rules outside of the engine itself. One change was made to the rule validator to allow for deserialized rules (empty set enumerator returns a count of 0, not null).  