### PR TITLE
Table keys

### DIFF
--- a/demo/DemoApp.EFDataExample/RulesEngineDemoContext.cs
+++ b/demo/DemoApp.EFDataExample/RulesEngineDemoContext.cs
@@ -43,7 +43,8 @@ namespace DemoApp.EFDataExample
               .HasKey(k => k.Name);
 
             modelBuilder.Entity<WorkflowRules>(entity => {
-                entity.HasKey(k => k.WorkflowName);
+                entity.HasKey(k => k.Id);
+                entity.Property(p => p.Id).ValueGeneratedOnAdd();
             });
 
             modelBuilder.Entity<RuleActions>(entity => {
@@ -53,7 +54,8 @@ namespace DemoApp.EFDataExample
             });
 
             modelBuilder.Entity<Rule>(entity => {
-                entity.HasKey(k => k.RuleName);
+                entity.HasKey(k => k.Id);
+                entity.Property(p => p.Id).ValueGeneratedOnAdd();
 
                 entity.Property(b => b.Properties)
                 .HasConversion(

--- a/src/RulesEngine/Models/Rule.cs
+++ b/src/RulesEngine/Models/Rule.cs
@@ -16,6 +16,11 @@ namespace RulesEngine.Models
     public class Rule
     {
         /// <summary>
+        /// Gets the Rule Id.
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
         /// Rule name for the Rule
         /// </summary>
         public string RuleName { get; set; }

--- a/src/RulesEngine/Models/WorkflowRules.cs
+++ b/src/RulesEngine/Models/WorkflowRules.cs
@@ -13,6 +13,11 @@ namespace RulesEngine.Models
     public class WorkflowRules
     {
         /// <summary>
+        /// Gets the workflow Id.
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
         /// Gets the workflow name.
         /// </summary>
         public string WorkflowName { get; set; }


### PR DESCRIPTION
Ids for the 2 main tables would be useful.

Writing an Editor and using the Name as the key (current) makes renaming a workflow or rule impossible (unless the whole record is dropped/recreated).

This PR does not require the Id in JSON and is backward compatible.