### PR TITLE
Add ContainsWorkflow method to check if workflow exists

### DIFF
--- a/src/RulesEngine/Interfaces/IRulesEngine.cs
+++ b/src/RulesEngine/Interfaces/IRulesEngine.cs
@@ -44,6 +44,13 @@ namespace RulesEngine.Interfaces
         void RemoveWorkflow(params string[] workflowNames);
 
         /// <summary>
+        /// Checks is workflow exist.
+        /// </summary>
+        /// <param name="workflowName">The workflow name.</param>
+        /// <returns> <c>true</c> if contains the specified workflow name; otherwise, <c>false</c>.</returns>
+        bool ContainsWorkflow(string workflowName);
+
+        /// <summary>
         /// Returns the list of all registered workflow names
         /// </summary>
         /// <returns></returns>

--- a/src/RulesEngine/RulesEngine.cs
+++ b/src/RulesEngine/RulesEngine.cs
@@ -212,6 +212,16 @@ namespace RulesEngine
         }
 
         /// <summary>
+        /// Checks is workflow exist.
+        /// </summary>
+        /// <param name="workflowName">The workflow name.</param>
+        /// <returns> <c>true</c> if contains the specified workflow name; otherwise, <c>false</c>.</returns>
+        public bool ContainsWorkflow(string workflowName)
+        {
+            return _rulesCache.ContainsWorkflows(workflowName);
+        }
+
+        /// <summary>
         /// Clears the workflow.
         /// </summary>
         public void ClearWorkflows()

--- a/test/RulesEngine.UnitTest/BusinessRuleEngineTest.cs
+++ b/test/RulesEngine.UnitTest/BusinessRuleEngineTest.cs
@@ -722,6 +722,29 @@ namespace RulesEngine.UnitTest
 
         }
 
+        [Fact]
+        public void ContainsWorkFlowName_ShouldReturn()
+        {
+            const string ExistedWorkflowName = "ExistedWorkflowName";
+            const string NotExistedWorkflowName = "NotExistedWorkflowName";
+
+            var workflow = new Workflow {
+                WorkflowName = ExistedWorkflowName,
+                Rules = new Rule[]{
+                    new Rule {
+                        RuleName = "Rule",
+                        RuleExpressionType = RuleExpressionType.LambdaExpression,
+                        Expression = "1==1"
+                    }
+                }
+            };
+
+            var re = new RulesEngine();
+            re.AddWorkflow(workflow);
+
+            Assert.True(re.ContainsWorkflow(ExistedWorkflowName));
+            Assert.False(re.ContainsWorkflow(NotExistedWorkflowName));
+        }
 
         [Theory]
         [InlineData(typeof(RulesEngine),typeof(IRulesEngine))]


### PR DESCRIPTION
This PR adds ContainsWorkflow(string workflowName) method  to check if workflow exists before executing rules