### PR TITLE
Update RulesEngineContext.cs

### DIFF
--- a/demo/DemoApp.EFDataExample/RulesEngineContext.cs
+++ b/demo/DemoApp.EFDataExample/RulesEngineContext.cs
@@ -40,6 +40,7 @@ namespace RulesEngine.Data
                    v => JsonSerializer.Deserialize<RuleActions>(v, serializationOptions));
 
                 entity.Ignore(b => b.WorkflowsToInject);
+                entity.Ignore(b => b.WorkflowRulesToInject);
             });
         }
     }


### PR DESCRIPTION
This commit adds a line to RulesEngineContext.cs to make Entity Framework Core ignore WorkflowRulesToInject as well as WorkflowsToInject, which resolves an error causing the demo program to crash.  This fixes issue #346.