### PR TITLE
suggested fix for issue #384

### DIFF
--- a/src/RulesEngine/RulesEngine.cs
+++ b/src/RulesEngine/RulesEngine.cs
@@ -101,7 +101,9 @@ namespace RulesEngine
         /// <returns>List of rule results</returns>
         public async ValueTask<List<RuleResultTree>> ExecuteAllRulesAsync(string workflowName, params RuleParameter[] ruleParams)
         {
-            var ruleResultList = ValidateWorkflowAndExecuteRule(workflowName, ruleParams);
+            var sortedRuleParams = ruleParams.ToList();
+            sortedRuleParams.Sort((RuleParameter a, RuleParameter b) => string.Compare(a.Name, b.Name));
+            var ruleResultList = ValidateWorkflowAndExecuteRule(workflowName, sortedRuleParams.ToArray());
             await ExecuteActionAsync(ruleResultList);
             return ruleResultList;
         }
@@ -343,7 +345,7 @@ namespace RulesEngine
 
         private string GetCompiledRulesKey(string workflowName, RuleParameter[] ruleParams)
         {
-            var key = $"{workflowName}-" + string.Join("-", ruleParams.Select(c => c.Type.Name));
+            var key = $"{workflowName}-" + string.Join("-", ruleParams.Select(c => $"{c.Name}_{c.Type.Name}"));
             return key;
         }
 

--- a/src/RulesEngine/RulesEngine.cs
+++ b/src/RulesEngine/RulesEngine.cs
@@ -345,7 +345,8 @@ namespace RulesEngine
 
         private string GetCompiledRulesKey(string workflowName, RuleParameter[] ruleParams)
         {
-            var key = $"{workflowName}-" + string.Join("-", ruleParams.Select(c => $"{c.Name}_{c.Type.Name}"));
+            var ruleParamsHash = string.Join("-", ruleParams.Select(c => $"{c.Name}_{c.Type.Name}")).GetHashCode();
+            var key = $"{workflowName}-" + ruleParamsHash;
             return key;
         }
 

--- a/test/RulesEngine.UnitTest/ParameterNameChangeTest.cs
+++ b/test/RulesEngine.UnitTest/ParameterNameChangeTest.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using RulesEngine.Models;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Dynamic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RulesEngine.UnitTest
+{
+  [ExcludeFromCodeCoverage]
+  public class ParameterNameChangeTest
+  {
+    [Fact]
+    public async Task RunTwiceTest_ReturnsExpectedResults()
+    {
+      var workflow = new Workflow {
+        WorkflowName = "ParameterNameChangeWorkflow",
+        Rules = new Rule[] {
+          new Rule {
+            RuleName = "ParameterNameChangeRule",
+            RuleExpressionType = RuleExpressionType.LambdaExpression,
+            Expression = "test.blah == 1"
+          }
+        }
+      };
+      var engine = new RulesEngine();
+      engine.AddOrUpdateWorkflow(workflow);
+
+      dynamic dynamicBlah = new ExpandoObject();
+      dynamicBlah.blah = (Int64)1;
+      var input_pass = new RuleParameter("test", dynamicBlah);
+      var input_fail = new RuleParameter("SOME_OTHER_NAME", dynamicBlah);
+      // RuleParameter name matches expression, so should pass.
+      var pass_results = await engine.ExecuteAllRulesAsync("ParameterNameChangeWorkflow", input_pass);
+      // RuleParameter name DOES NOT MATCH expression, so should fail.
+      var fail_results = await engine.ExecuteAllRulesAsync("ParameterNameChangeWorkflow", input_fail);
+      Assert.True(pass_results.First().IsSuccess);
+      Assert.False(fail_results.First().IsSuccess);
+    }
+  }
+}

--- a/test/RulesEngine.UnitTest/ParameterNameChangeTest.cs
+++ b/test/RulesEngine.UnitTest/ParameterNameChangeTest.cs
@@ -11,35 +11,35 @@ using Xunit;
 
 namespace RulesEngine.UnitTest
 {
-  [ExcludeFromCodeCoverage]
-  public class ParameterNameChangeTest
-  {
-    [Fact]
-    public async Task RunTwiceTest_ReturnsExpectedResults()
+    [ExcludeFromCodeCoverage]
+    public class ParameterNameChangeTest
     {
-      var workflow = new Workflow {
-        WorkflowName = "ParameterNameChangeWorkflow",
-        Rules = new Rule[] {
-          new Rule {
-            RuleName = "ParameterNameChangeRule",
-            RuleExpressionType = RuleExpressionType.LambdaExpression,
-            Expression = "test.blah == 1"
-          }
-        }
-      };
-      var engine = new RulesEngine();
-      engine.AddOrUpdateWorkflow(workflow);
+        [Fact]
+        public async Task RunTwiceTest_ReturnsExpectedResults()
+        {
+            var workflow = new Workflow {
+                WorkflowName = "ParameterNameChangeWorkflow",
+                Rules = new Rule[] {
+                    new Rule {
+                        RuleName = "ParameterNameChangeRule",
+                        RuleExpressionType = RuleExpressionType.LambdaExpression,
+                        Expression = "test.blah == 1"
+                    }
+                }
+            };
+            var engine = new RulesEngine();
+            engine.AddOrUpdateWorkflow(workflow);
 
-      dynamic dynamicBlah = new ExpandoObject();
-      dynamicBlah.blah = (Int64)1;
-      var input_pass = new RuleParameter("test", dynamicBlah);
-      var input_fail = new RuleParameter("SOME_OTHER_NAME", dynamicBlah);
-      // RuleParameter name matches expression, so should pass.
-      var pass_results = await engine.ExecuteAllRulesAsync("ParameterNameChangeWorkflow", input_pass);
-      // RuleParameter name DOES NOT MATCH expression, so should fail.
-      var fail_results = await engine.ExecuteAllRulesAsync("ParameterNameChangeWorkflow", input_fail);
-      Assert.True(pass_results.First().IsSuccess);
-      Assert.False(fail_results.First().IsSuccess);
+            dynamic dynamicBlah = new ExpandoObject();
+            dynamicBlah.blah = (Int64)1;
+            var input_pass = new RuleParameter("test", dynamicBlah);
+            var input_fail = new RuleParameter("SOME_OTHER_NAME", dynamicBlah);
+            // RuleParameter name matches expression, so should pass.
+            var pass_results = await engine.ExecuteAllRulesAsync("ParameterNameChangeWorkflow", input_pass);
+            // RuleParameter name DOES NOT MATCH expression, so should fail.
+            var fail_results = await engine.ExecuteAllRulesAsync("ParameterNameChangeWorkflow", input_fail);
+            Assert.True(pass_results.First().IsSuccess);
+            Assert.False(fail_results.First().IsSuccess);
+        }
     }
-  }
 }


### PR DESCRIPTION
The compiled rules keys now contains the name of each RuleParameter, sorted alphabetically.
Without this, the attached test fails.