### PR TITLE
Update MemCache.cs

### DIFF
--- a/src/RulesEngine/HelperFunctions/MemCache.cs
+++ b/src/RulesEngine/HelperFunctions/MemCache.cs
@@ -79,6 +79,10 @@ namespace RulesEngine.HelperFunctions
 
         public T Set<T>(string key, T value, DateTimeOffset? expiry = null)
         {
+            if (_config.SizeLimit < 1)
+            {
+                return T;
+            }
             var fixedExpiry = expiry ?? DateTimeOffset.MaxValue;
 
             while (_cacheDictionary.Count > _config.SizeLimit)


### PR DESCRIPTION
We need to disable memory cache. If we set size limit to 0 or negative it will always try to clear queue. There is a defect here.

![Capture](https://user-images.githubusercontent.com/16115416/219676954-ea8322b9-259a-49f5-8e50-d504fec9e6c6.PNG)
