### PR TITLE
Bump System.Linq.Dynamic.Core from 1.2.22 to 1.3.3

### DIFF
--- a/src/RulesEngine/RulesEngine.csproj
+++ b/src/RulesEngine/RulesEngine.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
-    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.22" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.3.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>


### PR DESCRIPTION
Versions under 1.3.0 are susceptible to CVE-2023-32571 -https://research.nccgroup.com/2023/06/13/dynamic-linq-injection-remote-code-execution-vulnerability-cve-2023-32571/