### PR TITLE
Public Factory Method for Rule Parameter From Type

### DIFF
--- a/src/RulesEngine/Models/RuleParameter.cs
+++ b/src/RulesEngine/Models/RuleParameter.cs
@@ -21,6 +21,12 @@ namespace RulesEngine.Models
         {
             Init(name, type);
         }
+
+        public static RuleParameter Create(string name, Type type)
+        {
+            return new RuleParameter(name, type);
+        }
+
         public Type Type { get; private set; }
         public string Name { get; private set; }
         public object Value { get; private set; }

--- a/test/RulesEngine.UnitTest/RuleParameterTests.cs
+++ b/test/RulesEngine.UnitTest/RuleParameterTests.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AutoFixture;
+using RulesEngine.Models;
+using System;
+using Xunit;
+
+namespace RulesEngine.UnitTest;
+public class RuleParameterTests
+{
+    [Fact]
+    public void Create_SetsPropertiesCorrectly()
+    {
+        var fixture = new Fixture();
+        var name = fixture.Create<string>();
+        var type = fixture.Create<Type>();
+
+        var result = RuleParameter.Create(name, type);
+
+        Assert.Equal(name, result.Name);
+        Assert.Equal(type, result.Type);
+    }
+}


### PR DESCRIPTION
If the `RuleParameter`'s type is only known via a `Type` at runtime, it becomes non-trivial to create a pseudo-object of that `Type` in order to create a `RuleParameter`.  For instance, `Activator.CreateInstance` throws when attempting to create a `string`

It would be ideal if the `RuleParameter` could be created directly from the `Name` and `Type` pair as the internal implementation does.

In this PR, I elected to create a static factory method over publicizing the constructor to avoid overload confusion of `Name, Value` and `Name, Type` - theoretically a consumer could be passing in a `Type` into the `object` constructor, and publicizing the constructor could potentially be a breaking change.