### PR TITLE
perf: Optimize the processing speed of EvaluateRuleAction

### DIFF
--- a/src/RulesEngine/Actions/ActionContext.cs
+++ b/src/RulesEngine/Actions/ActionContext.cs
@@ -45,6 +45,13 @@ namespace RulesEngine.Actions
         {
             try
             {
+                //key not found return
+                //Returning a KeyNotFoundException has a significant impact on performance.
+                if (!_context.ContainsKey(name))
+                {
+                    output = default(T);
+                    return false;
+                }
                 output =  GetContext<T>(name);
                 return true;
             }


### PR DESCRIPTION
The TryGetContext method is only used in EvaluateRuleAction
If catch KeyNotFoundException , Will have a significant impact on the performance of a large number of workflows
