### PR TITLE
Fix CustomTypeProvider Initialization Error with System.Linq.Dynamic.Core v1.4.0+

### DIFF
--- a/src/RulesEngine/CustomTypeProvider.cs
+++ b/src/RulesEngine/CustomTypeProvider.cs
@@ -4,6 +4,7 @@
 using RulesEngine.HelperFunctions;
 using System;
 using System.Collections.Generic;
+using System.Linq.Dynamic.Core;
 using System.Linq.Dynamic.Core.CustomTypeProviders;
 
 namespace RulesEngine
@@ -11,7 +12,7 @@ namespace RulesEngine
     public class CustomTypeProvider : DefaultDynamicLinqCustomTypeProvider
     {
         private HashSet<Type> _types;
-        public CustomTypeProvider(Type[] types) : base()
+        public CustomTypeProvider(Type[] types) : base(ParsingConfig.Default)
         {
             _types = new HashSet<Type>(types ?? new Type[] { });
             _types.Add(typeof(ExpressionUtils));

--- a/src/RulesEngine/RulesEngine.csproj
+++ b/src/RulesEngine/RulesEngine.csproj
@@ -36,12 +36,12 @@
     <PackageReference Include="FastExpressionCompiler" Version="4.0.1" />
     <PackageReference Include="FluentValidation" Version="11.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.3.7" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.4.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0"/>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
 </Project>

--- a/test/RulesEngine.UnitTest/RulesEngine.UnitTest.csproj
+++ b/test/RulesEngine.UnitTest/RulesEngine.UnitTest.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="System.Text.Json" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
     <PackageReference Include="xunit" Version="2.6.5" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
### Issue: 
When a project that has a dependency on **RulesEngine** also includes a dependency on [System.Linq.Dynamic.Core](https://github.com/zzzprojects/System.Linq.Dynamic.Core) with version >= 1.4.0, calling the `RulesEngine.ExecuteAllRulesAsync()` method fails with the following error:

`Exception while parsing expression 'someExpressionHere' - Method not found: 'Void System.Linq.Dynamic.Core.CustomTypeProviders.DefaultDynamicLinqCustomTypeProvider..ctor(Boolean)'.`

### Cause:
Version 1.4.0 introduced a breaking change to the `DefaultDynamicLinqCustomTypeProvider` constructor. This change is detailed here: https://github.com/zzzprojects/System.Linq.Dynamic.Core/pull/807/files#diff-59a013aa11deb1923983dd1185ff649c2c327d2841621d18dff2991ebbef6d6dR30

### Fix:
To resolve this issue, pass `ParsingConfig.Default` to the constructor.