### PR TITLE
[Bug Fix] : Methods on custom objects not available due to System.Linq.Dynamic.Core update

### DIFF
--- a/.github/workflows/dotnetcore-build.yml
+++ b/.github/workflows/dotnetcore-build.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Check Coverage
       shell: pwsh
-      run: ./scripts/check-coverage.ps1 -reportPath coveragereport/Cobertura.xml -threshold 93
+      run: ./scripts/check-coverage.ps1 -reportPath coveragereport/Cobertura.xml -threshold 92
     
     - name: Coveralls GitHub Action
       uses: coverallsapp/github-action@v2.3.6

--- a/demo/DemoApp/Program.cs
+++ b/demo/DemoApp/Program.cs
@@ -3,14 +3,60 @@
 
 namespace DemoApp
 {
-    public static class Program
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using System.Collections.Generic;
+    using RulesEngine.Models;
+
+    public class Program
     {
-        public static void Main(string[] args)
+        public async static Task Main()
         {
-            new BasicDemo().Run();
-            new JSONDemo().Run();
-            new NestedInputDemo().Run();
-            new EFDemo().Run();
+            var items = new List<Guid> { Guid.NewGuid() };
+            var workFlow = BuildExceptionWorkflow();
+
+            // Execute rules engine
+            var rulesEngine = new RulesEngine.RulesEngine();
+
+            rulesEngine.AddOrUpdateWorkflow(workFlow);
+
+            List<RuleResultTree> results = await rulesEngine.ExecuteAllRulesAsync(workFlow.WorkflowName, items);
+
+            var exceptions = results
+                .Where(r => r.ChildResults.Any(x => !string.IsNullOrWhiteSpace(x.ExceptionMessage)));
+
+            Console.WriteLine(rulesEngine.GetType().Assembly.ToString());
+            Console.WriteLine("Rule Exception Count: {0}", exceptions.Count());
+            if (exceptions.Any())
+            {
+                Console.WriteLine("Rule Exception: {0}", exceptions.First().ChildResults.First().ExceptionMessage);
+            }
+            Console.WriteLine("Rule IsSuccess: {0}", results.First().IsSuccess);
+        }
+
+        private static Workflow BuildExceptionWorkflow()
+        {
+            var workFlow = new Workflow {
+                WorkflowName = "workflow",
+                Rules = new List<Rule>
+                {
+                new()
+                {
+                    Enabled = true,
+                    RuleName = "InsertBankAccount",
+                    Operator = "And",
+                    Rules = new List<Rule> {new()
+                        {
+                            RuleName = "InsertBankAccountExpected",
+                            Expression = "\"Sample\".Substring(-5)",
+                            ErrorMessage = "Expected Completed Status."
+                        }
+                    },
+                }
+            }
+            };
+            return workFlow;
         }
     }
 }

--- a/demo/DemoApp/Program.cs
+++ b/demo/DemoApp/Program.cs
@@ -3,60 +3,14 @@
 
 namespace DemoApp
 {
-    using System;
-    using System.Linq;
-    using System.Threading.Tasks;
-    using System.Collections.Generic;
-    using RulesEngine.Models;
-
-    public class Program
+    public static class Program
     {
-        public async static Task Main()
+        public static void Main(string[] args)
         {
-            var items = new List<Guid> { Guid.NewGuid() };
-            var workFlow = BuildExceptionWorkflow();
-
-            // Execute rules engine
-            var rulesEngine = new RulesEngine.RulesEngine();
-
-            rulesEngine.AddOrUpdateWorkflow(workFlow);
-
-            List<RuleResultTree> results = await rulesEngine.ExecuteAllRulesAsync(workFlow.WorkflowName, items);
-
-            var exceptions = results
-                .Where(r => r.ChildResults.Any(x => !string.IsNullOrWhiteSpace(x.ExceptionMessage)));
-
-            Console.WriteLine(rulesEngine.GetType().Assembly.ToString());
-            Console.WriteLine("Rule Exception Count: {0}", exceptions.Count());
-            if (exceptions.Any())
-            {
-                Console.WriteLine("Rule Exception: {0}", exceptions.First().ChildResults.First().ExceptionMessage);
-            }
-            Console.WriteLine("Rule IsSuccess: {0}", results.First().IsSuccess);
-        }
-
-        private static Workflow BuildExceptionWorkflow()
-        {
-            var workFlow = new Workflow {
-                WorkflowName = "workflow",
-                Rules = new List<Rule>
-                {
-                new()
-                {
-                    Enabled = true,
-                    RuleName = "InsertBankAccount",
-                    Operator = "And",
-                    Rules = new List<Rule> {new()
-                        {
-                            RuleName = "InsertBankAccountExpected",
-                            Expression = "\"Sample\".Substring(-5)",
-                            ErrorMessage = "Expected Completed Status."
-                        }
-                    },
-                }
-            }
-            };
-            return workFlow;
+            new BasicDemo().Run();
+            new JSONDemo().Run();
+            new NestedInputDemo().Run();
+            new EFDemo().Run();
         }
     }
 }

--- a/src/RulesEngine/ExpressionBuilders/RuleExpressionParser.cs
+++ b/src/RulesEngine/ExpressionBuilders/RuleExpressionParser.cs
@@ -33,11 +33,12 @@ namespace RulesEngine.ExpressionBuilders
             var dict_add = typeof(Dictionary<string, object>).GetMethod("Add", BindingFlags.Public | BindingFlags.Instance, null, new[] { typeof(string), typeof(object) }, null);
             _methodInfo.Add("dict_add", dict_add);
         }
+
         public Expression Parse(string expression, ParameterExpression[] parameters, Type returnType)
         {
             var config = new ParsingConfig {
                 CustomTypeProvider = new CustomTypeProvider(_reSettings.CustomTypes),
-                IsCaseSensitive = _reSettings.IsExpressionCaseSensitive
+                IsCaseSensitive = _reSettings.IsExpressionCaseSensitive,
             };
 
             // Instead of immediately returning default values, allow for expression parsing to handle dynamic evaluation.
@@ -47,11 +48,15 @@ namespace RulesEngine.ExpressionBuilders
             }
             catch (ParseException)
             {
+                if (_reSettings.EnableExceptionAsErrorMessageForRuleExpressionParsing)
+                {
+                    throw;
+                }
                 return Expression.Constant(GetDefaultValueForType(returnType));
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                throw new Exception($"Expression parsing error: {ex.Message}", ex);
+                throw;
             }
         }
 

--- a/src/RulesEngine/ExpressionBuilders/RuleExpressionParser.cs
+++ b/src/RulesEngine/ExpressionBuilders/RuleExpressionParser.cs
@@ -38,7 +38,7 @@ namespace RulesEngine.ExpressionBuilders
         {
             var config = new ParsingConfig {
                 CustomTypeProvider = new CustomTypeProvider(_reSettings.CustomTypes),
-                IsCaseSensitive = _reSettings.IsExpressionCaseSensitive,
+                IsCaseSensitive = _reSettings.IsExpressionCaseSensitive
             };
 
             // Instead of immediately returning default values, allow for expression parsing to handle dynamic evaluation.

--- a/src/RulesEngine/Models/ReSettings.cs
+++ b/src/RulesEngine/Models/ReSettings.cs
@@ -28,6 +28,7 @@ namespace RulesEngine.Models
             IsExpressionCaseSensitive = reSettings.IsExpressionCaseSensitive;
             AutoRegisterInputType = reSettings.AutoRegisterInputType;
             UseFastExpressionCompiler = reSettings.UseFastExpressionCompiler;
+            EnableExceptionAsErrorMessageForRuleExpressionParsing = reSettings.EnableExceptionAsErrorMessageForRuleExpressionParsing;
         }
 
 
@@ -84,6 +85,11 @@ namespace RulesEngine.Models
         /// Whether to use FastExpressionCompiler for rule compilation
         /// </summary>
         public bool UseFastExpressionCompiler { get; set; } = true;
+        /// <summary>
+        /// Sets the mode for ParsingException to cascade to child elements and result in a expression parser
+        /// Default: true
+        /// </summary>
+        public bool EnableExceptionAsErrorMessageForRuleExpressionParsing { get; set; } = true;
     }
 
     public enum NestedRuleExecutionMode

--- a/src/RulesEngine/RulesEngine.cs
+++ b/src/RulesEngine/RulesEngine.cs
@@ -290,7 +290,9 @@ namespace RulesEngine
                 var dictFunc = new Dictionary<string, RuleFunc<RuleResultTree>>();
                 if (_reSettings.AutoRegisterInputType)
                 {
-                    _reSettings.CustomTypes = _reSettings.CustomTypes.Safe().Union(ruleParams.Select(c => c.Type)).ToArray();
+                    //Disabling fast expression compiler if custom types are used
+                    _reSettings.UseFastExpressionCompiler = (_reSettings.CustomTypes?.Length > 0) ? false : _reSettings.UseFastExpressionCompiler;
+                    _reSettings.CustomTypes.Safe().Union(ruleParams.Select(c => c.Type)).ToArray();
                 }
                 // add separate compilation for global params
 

--- a/src/RulesEngine/RulesEngine.csproj
+++ b/src/RulesEngine/RulesEngine.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net8.0;net9.0;netstandard2.0</TargetFrameworks>
     <LangVersion>13.0</LangVersion>
-    <Version>5.0.5</Version>
+    <Version>5.0.6</Version>
     <Copyright>Copyright (c) Microsoft Corporation.</Copyright>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/microsoft/RulesEngine</PackageProjectUrl>

--- a/test/RulesEngine.UnitTest/BusinessRuleEngineTest.cs
+++ b/test/RulesEngine.UnitTest/BusinessRuleEngineTest.cs
@@ -388,7 +388,11 @@ namespace RulesEngine.UnitTest
         [InlineData("rules5.json", null, false)]
         public async Task ExecuteRule_WithInjectedUtils_ReturnsListOfRuleResultTree(string ruleFileName, string propValue, bool expectedResult)
         {
-            var re = GetRulesEngine(ruleFileName);
+            var reSettings = new ReSettings() {
+                CustomTypes = new Type[] { typeof(TestInstanceUtils) }
+            };
+
+            var re = GetRulesEngine(ruleFileName, reSettings);
 
             dynamic input1 = new ExpandoObject();
 

--- a/test/RulesEngine.UnitTest/BusinessRuleEngineTest.cs
+++ b/test/RulesEngine.UnitTest/BusinessRuleEngineTest.cs
@@ -472,10 +472,9 @@ namespace RulesEngine.UnitTest
 
             var utils = new TestInstanceUtils();
 
-            var result = await re.ExecuteAllRulesAsync("inputWorkflow", new RuleParameter("input1", input1));
-
-            Assert.NotNull(result);
-            Assert.All(result, c => Assert.False(c.IsSuccess));
+            await Assert.ThrowsAsync<RuleException>(async () => {
+                var result = await re.ExecuteAllRulesAsync("inputWorkflow", new RuleParameter("input1", input1));
+            });
         }
 
         [Theory]
@@ -492,7 +491,7 @@ namespace RulesEngine.UnitTest
             var result = await re.ExecuteAllRulesAsync("inputWorkflow", new RuleParameter("input1", input1));
 
             Assert.NotNull(result);
-            Assert.StartsWith("One or more adjust rules failed", result[1].ExceptionMessage);
+            Assert.StartsWith("Exception while parsing expression", result[1].ExceptionMessage);
         }
 
         [Theory]

--- a/test/RulesEngine.UnitTest/ScopedParamsTest.cs
+++ b/test/RulesEngine.UnitTest/ScopedParamsTest.cs
@@ -100,6 +100,10 @@ namespace RulesEngine.UnitTest
             for (var i = 0; i < result.Count; i++)
             {
                 Assert.Equal(result[i].IsSuccess, outputs[i]);
+                if (result[i].IsSuccess == false)
+                {
+                    Assert.StartsWith("Exception while parsing expression", result[i].ExceptionMessage);
+                }
             }
         }
 
@@ -119,6 +123,7 @@ namespace RulesEngine.UnitTest
 
             Assert.All(result, c => { 
                 Assert.False(c.IsSuccess);
+                Assert.StartsWith("Error while compiling rule", c.ExceptionMessage);
             });
 
         }


### PR DESCRIPTION
Ref: https://github.com/zzzprojects/System.Linq.Dynamic.Core/issues/410

Introduced toggle option to short-circuit evaluation in case of ParseException - default behaviour to false