### PR TITLE
One rule execution

### DIFF
--- a/src/RulesEngine/RulesEngine.cs
+++ b/src/RulesEngine/RulesEngine.cs
@@ -111,7 +111,7 @@ namespace RulesEngine
         }
 
         /// <summary>
-        /// This will executea specific rule of the specified workflow
+        /// This will execute a specific rule of the specified workflow
         /// </summary>
         /// <param name="workflowName">The name of the workflow with rules to execute against the inputs</param>
         /// <param name="ruleName">The name of the rule to execute</param>

--- a/src/RulesEngine/RulesEngine.cs
+++ b/src/RulesEngine/RulesEngine.cs
@@ -142,6 +142,13 @@ namespace RulesEngine
             }
         }
 
+        public async ValueTask<ActionRuleResult> ExecuteActionWorkflowAsync(string workflowName, string ruleName, RuleParameter[] ruleParameters)
+        {
+            var compiledRule = CompileRule(workflowName, ruleName, ruleParameters);
+            var resultTree = compiledRule(ruleParameters);
+            return await ExecuteActionForRuleResult(resultTree, true);
+        }
+
         private async ValueTask<ActionRuleResult> ExecuteActionForRuleResult(RuleResultTree resultTree, bool includeRuleResults = false)
         {
             var ruleActions = resultTree?.Rule?.Actions;


### PR DESCRIPTION
Makes it possible to execute a single rule by taking advantage of the workflow cache.
Also allows to execute actions of child rules.