### PR TITLE
[Bug Fix] Handling of Automatic Type Registration

### DIFF
--- a/.github/workflows/dotnetcore-build.yml
+++ b/.github/workflows/dotnetcore-build.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Check Coverage
       shell: pwsh
-      run: ./scripts/check-coverage.ps1 -reportPath coveragereport/Cobertura.xml -threshold 92
+      run: ./scripts/check-coverage.ps1 -reportPath coveragereport/Cobertura.xml -threshold 94
     
     - name: Coveralls GitHub Action
       uses: coverallsapp/github-action@v2.3.6

--- a/src/RulesEngine/CustomTypeProvider.cs
+++ b/src/RulesEngine/CustomTypeProvider.cs
@@ -3,7 +3,9 @@
 
 using RulesEngine.HelperFunctions;
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Dynamic.Core;
 using System.Linq.Dynamic.Core.CustomTypeProviders;
 
@@ -11,16 +13,40 @@ namespace RulesEngine
 {
     public class CustomTypeProvider : DefaultDynamicLinqCustomTypeProvider
     {
-        private HashSet<Type> _types;
+        private readonly HashSet<Type> _types;
+
         public CustomTypeProvider(Type[] types) : base(ParsingConfig.Default)
         {
-            _types = new HashSet<Type>(types ?? new Type[] { });
+            _types = new HashSet<Type>(types ?? Array.Empty<Type>());
+
             _types.Add(typeof(ExpressionUtils));
+
+            _types.Add(typeof(Enumerable));
+
+            var queue = new Queue<Type>(_types);
+            while (queue.Count > 0)
+            {
+                var t = queue.Dequeue();
+
+                var baseType = t.BaseType;
+                if (baseType != null && _types.Add(baseType))
+                    queue.Enqueue(baseType);
+
+                foreach (var interfaceType in t.GetInterfaces())
+                {
+                    if (_types.Add(interfaceType))
+                        queue.Enqueue(interfaceType);
+                }
+            }
+
+            _types.Add(typeof(IEnumerable));
         }
 
         public override HashSet<Type> GetCustomTypes()
         {
-            return _types;
+            var all = new HashSet<Type>(base.GetCustomTypes());
+            all.UnionWith(_types);
+            return all;
         }
     }
 }

--- a/src/RulesEngine/Models/ReSettings.cs
+++ b/src/RulesEngine/Models/ReSettings.cs
@@ -84,7 +84,7 @@ namespace RulesEngine.Models
         /// <summary>
         /// Whether to use FastExpressionCompiler for rule compilation
         /// </summary>
-        public bool UseFastExpressionCompiler { get; set; } = true;
+        public bool UseFastExpressionCompiler { get; set; } = false;
         /// <summary>
         /// Sets the mode for ParsingException to cascade to child elements and result in a expression parser
         /// Default: true

--- a/src/RulesEngine/RulesEngine.csproj
+++ b/src/RulesEngine/RulesEngine.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net8.0;net9.0;netstandard2.0</TargetFrameworks>
     <LangVersion>13.0</LangVersion>
-    <Version>5.0.6</Version>
+    <Version>5.0.7</Version>
     <Copyright>Copyright (c) Microsoft Corporation.</Copyright>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/microsoft/RulesEngine</PackageProjectUrl>

--- a/src/RulesEngine/RulesEngine.csproj
+++ b/src/RulesEngine/RulesEngine.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net8.0;net9.0;netstandard2.0</TargetFrameworks>
     <LangVersion>13.0</LangVersion>
-    <Version>5.0.7</Version>
+    <Version>6.0.0</Version>
     <Copyright>Copyright (c) Microsoft Corporation.</Copyright>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/microsoft/RulesEngine</PackageProjectUrl>

--- a/test/RulesEngine.UnitTest/CustomTypeProviderTests.cs
+++ b/test/RulesEngine.UnitTest/CustomTypeProviderTests.cs
@@ -3,7 +3,9 @@
 
 using Moq;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Xunit;
 
 namespace RulesEngine.UnitTest
@@ -12,33 +14,84 @@ namespace RulesEngine.UnitTest
     [ExcludeFromCodeCoverage]
     public class CustomTypeProviderTests : IDisposable
     {
-        private readonly MockRepository _mockRepository;
-        public CustomTypeProviderTests()
-        {
-            _mockRepository = new MockRepository(MockBehavior.Strict);
-        }
-
         public void Dispose()
         {
-            _mockRepository.VerifyAll();
         }
 
-        private CustomTypeProvider CreateProvider()
+        private CustomTypeProvider CreateProvider(params Type[] customTypes)
         {
-            return new CustomTypeProvider(null);
+            return new CustomTypeProvider(customTypes);
         }
 
         [Fact]
-        public void GetCustomTypes_StateUnderTest_ExpectedBehavior()
+        public void GetCustomTypes_DefaultProvider_IncludesEnumerableAndObject()
         {
-            // Arrange
-            var unitUnderTest = CreateProvider();
+            var provider = CreateProvider();
+            var allTypes = provider.GetCustomTypes();
+            Assert.NotEmpty(allTypes);
+            Assert.Contains(typeof(System.Linq.Enumerable), allTypes);
+            Assert.Contains(typeof(object), allTypes);
+        }
 
-            // Act
-            var result = unitUnderTest.GetCustomTypes();
+        [Fact]
+        public void GetCustomTypes_WithListOfGuid_ContainsIEnumerableOfGuid()
+        {
+            var initial = new[] { typeof(List<Guid>) };
+            var provider = CreateProvider(initial);
+            var allTypes = provider.GetCustomTypes();
+            Assert.Contains(typeof(IEnumerable<Guid>), allTypes);
+            Assert.Contains(typeof(List<Guid>), allTypes);
+            Assert.Contains(typeof(System.Linq.Enumerable), allTypes);
+            Assert.Contains(typeof(object), allTypes);
+        }
 
-            // Assert
-            Assert.NotEmpty(result);
+        [Fact]
+        public void GetCustomTypes_ListOfListString_ContainsIEnumerableOfListString()
+        {
+            var nestedListType = typeof(List<List<string>>);
+            var provider = CreateProvider(nestedListType);
+            var allTypes = provider.GetCustomTypes();
+            Assert.Contains(typeof(IEnumerable<List<string>>), allTypes);
+            Assert.Contains(nestedListType, allTypes);
+            Assert.Contains(typeof(System.Linq.Enumerable), allTypes);
+            Assert.Contains(typeof(object), allTypes);
+        }
+
+        [Fact]
+        public void GetCustomTypes_ArrayOfStringArrays_ContainsIEnumerableOfStringArray()
+        {
+            var arrayType = typeof(string[][]);
+            var provider = CreateProvider(arrayType);
+            var allTypes = provider.GetCustomTypes();
+            Assert.Contains(typeof(IEnumerable<string[]>), allTypes);
+            Assert.Contains(arrayType, allTypes);
+            Assert.Contains(typeof(System.Linq.Enumerable), allTypes);
+            Assert.Contains(typeof(object), allTypes);
+        }
+
+        [Fact]
+        public void GetCustomTypes_NullableIntArray_ContainsIEnumerableOfNullableInt()
+        {
+            var nullableInt = typeof(int?);
+            var arrayType = typeof(int?[]);
+            var provider = CreateProvider(arrayType);
+            var allTypes = provider.GetCustomTypes();
+            Assert.Contains(typeof(IEnumerable<int?>), allTypes);
+            Assert.Contains(arrayType, allTypes);
+            Assert.Contains(typeof(System.Linq.Enumerable), allTypes);
+            Assert.Contains(typeof(object), allTypes);
+        }
+
+        [Fact]
+        public void GetCustomTypes_MultipleTypes_NoDuplicates()
+        {
+            var repeatedType = typeof(List<string>);
+            var provider = CreateProvider(repeatedType, repeatedType);
+            var allTypes = provider.GetCustomTypes();
+            var matches = allTypes.Where(t => t == repeatedType).ToList();
+            Assert.Single(matches);
+            var interfaceMatches = allTypes.Where(t => t == typeof(IEnumerable<string>)).ToList();
+            Assert.Single(interfaceMatches);
         }
     }
 }


### PR DESCRIPTION
**Deep type registration**

1. ReSettings.AutoRegisterInputType now auto‐discovers generic, array, and nullable element types (e.g. List<List<T>>, T?[]).
2. All base classes and interfaces (e.g. IEnumerable<T>) are included automatically.

**Improved JSON/JToken handling**

1. No longer need to manually add JObject/JToken/JArray to CustomTypes. Rules using input["foo"][0]["bar"] compile and run out of the box.

2. Use Convert.ToString(...) (instead of .ToString()) on JTokens to avoid “Enumerable.ToString” conflicts.

**Nullable comparisons fixed**

1. Expressions like decimal? d < 20 now return false instead of throwing.

**Defaults tweaked**

1. UseFastExpressionCompiler defaults to false when custom types are present; re‐enable explicitly if needed.

**Unit test coverage**

1. New tests cover nested JSON rules, custom‐type provider edge cases, and nullable comparison.