### PR TITLE
Add .NET 10 / netstandard 2.1 support & fix Dictionary<string, object> regression (#720)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,6 +44,7 @@ jobs:
           6.0.x
           8.0.x
           9.0.x
+          10.0.x
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/dotnetcore-build.yml
+++ b/.github/workflows/dotnetcore-build.yml
@@ -18,6 +18,7 @@ jobs:
           6.0.x
           8.0.x
           9.0.x
+          10.0.x
     
     - name: Install dependencies
       run: dotnet restore RulesEngine.sln

--- a/benchmark/RulesEngineBenchmark/RulesEngineBenchmark.csproj
+++ b/benchmark/RulesEngineBenchmark/RulesEngineBenchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/demo/DemoApp.EFDataExample/DemoApp.EFDataExample.csproj
+++ b/demo/DemoApp.EFDataExample/DemoApp.EFDataExample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <RootNamespace>DemoApp.EFDataExample</RootNamespace>
     <AssemblyName>DemoApp.EFDataExample</AssemblyName>
   </PropertyGroup>

--- a/demo/DemoApp/DemoApp.csproj
+++ b/demo/DemoApp/DemoApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <StartupObject>DemoApp.Program</StartupObject>
   </PropertyGroup>
 

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "9.0.301",
+    "version": "10.0.100",
     "rollForward": "latestFeature",
-    "allowPrerelease": false
+    "allowPrerelease": true
   }
 }

--- a/src/RulesEngine/HelperFunctions/Utils.cs
+++ b/src/RulesEngine/HelperFunctions/Utils.cs
@@ -19,6 +19,11 @@ namespace RulesEngine.HelperFunctions
                 Type type = CreateAbstractClassType(input);
                 return CreateObject(type, input);
             }
+            else if (input is IDictionary<string, object> dict)
+            {
+                Type type = CreateAbstractClassTypeFromDictionary(dict);
+                return CreateObjectFromDictionary(type, dict);
+            }
             else
             {
                 return input;
@@ -128,6 +133,89 @@ namespace RulesEngine.HelperFunctions
             var methodInfo = typeof(Enumerable).GetMethod("ToList");
             var genericMethod = methodInfo.MakeGenericMethod(innerType);
             return genericMethod.Invoke(null, new[] { self }) as IList;
+        }
+
+        private static Type CreateAbstractClassTypeFromDictionary(IDictionary<string, object> dictionary)
+        {
+            List<DynamicProperty> props = [];
+
+            foreach (var kvp in dictionary)
+            {
+                Type valueType;
+                if (kvp.Value is ExpandoObject)
+                {
+                    valueType = CreateAbstractClassType(kvp.Value);
+                }
+                else if (kvp.Value is IDictionary<string, object> nestedDict)
+                {
+                    valueType = CreateAbstractClassTypeFromDictionary(nestedDict);
+                }
+                else if (kvp.Value is IList list)
+                {
+                    if (list.Count == 0)
+                    {
+                        valueType = typeof(List<object>);
+                    }
+                    else
+                    {
+                        var internalType = list[0] is IDictionary<string, object> innerDict
+                            ? CreateAbstractClassTypeFromDictionary(innerDict)
+                            : (list[0] is ExpandoObject ? CreateAbstractClassType(list[0]) : list[0]?.GetType() ?? typeof(object));
+                        valueType = new List<object>().Cast(internalType).ToList(internalType).GetType();
+                    }
+                }
+                else
+                {
+                    valueType = kvp.Value?.GetType() ?? typeof(object);
+                }
+                props.Add(new DynamicProperty(kvp.Key, valueType));
+            }
+
+            return DynamicClassFactory.CreateType(props);
+        }
+
+        private static object CreateObjectFromDictionary(Type type, IDictionary<string, object> dictionary)
+        {
+            var obj = Activator.CreateInstance(type);
+            var typeProps = type.GetProperties().ToDictionary(c => c.Name);
+
+            foreach (var kvp in dictionary)
+            {
+                if (typeProps.ContainsKey(kvp.Key) &&
+                    kvp.Value != null && (kvp.Value.GetType().Name != "DBNull" || kvp.Value != DBNull.Value))
+                {
+                    object val;
+                    var propInfo = typeProps[kvp.Key];
+                    if (kvp.Value is ExpandoObject)
+                    {
+                        val = CreateObject(propInfo.PropertyType, kvp.Value);
+                    }
+                    else if (kvp.Value is IDictionary<string, object> nestedDict)
+                    {
+                        val = CreateObjectFromDictionary(propInfo.PropertyType, nestedDict);
+                    }
+                    else if (kvp.Value is IList temp)
+                    {
+                        var internalType = propInfo.PropertyType.GenericTypeArguments.FirstOrDefault() ?? typeof(object);
+                        var newList = new List<object>().Cast(internalType).ToList(internalType);
+                        foreach (var t in temp)
+                        {
+                            var child = t is IDictionary<string, object> d
+                                ? CreateObjectFromDictionary(internalType, d)
+                                : (t is ExpandoObject ? CreateObject(internalType, t) : t);
+                            newList.Add(child);
+                        }
+                        val = newList;
+                    }
+                    else
+                    {
+                        val = kvp.Value;
+                    }
+                    propInfo.SetValue(obj, val, null);
+                }
+            }
+
+            return obj;
         }
     }
 

--- a/src/RulesEngine/RulesEngine.csproj
+++ b/src/RulesEngine/RulesEngine.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net9.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net9.0;net10.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>13.0</LangVersion>
     <Version>6.0.0</Version>
     <Copyright>Copyright (c) Microsoft Corporation.</Copyright>
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <Choose>
-    <When Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'netstandard2.0'">
+    <When Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'">
       <ItemGroup>
         <PackageReference Include="System.Text.Json" Version="6.0.11" />
       </ItemGroup>
@@ -53,7 +53,7 @@
     </Otherwise>
   </Choose>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0"/>
   </ItemGroup>
 

--- a/test/RulesEngine.UnitTest/RuleExpressionParserTests/RuleExpressionParserTests.cs
+++ b/test/RulesEngine.UnitTest/RuleExpressionParserTests/RuleExpressionParserTests.cs
@@ -69,6 +69,42 @@ namespace RulesEngine.UnitTest.RuleExpressionParserTests
             var result = ruleParser.Evaluate<bool>("d1 < 20", new[] { Models.RuleParameter.Create("d1", d1) });
             Assert.False(result);
         }
+
+        [Fact]
+        public void TestExpressionWithDictionaryParameter()
+        {
+            var parser = new RuleExpressionParser(new ReSettings());
+
+            var payload = new System.Collections.Generic.Dictionary<string, object>
+            {
+                { "Formule", "Essentielle" }
+            };
+
+            var ruleParameters = new[] { RuleParameter.Create("_", payload) };
+
+            var resultNotEqual = parser.Evaluate<bool>("Formule != \"Essentielle\"", ruleParameters);
+            Assert.False(resultNotEqual);
+
+            var resultEqual = parser.Evaluate<bool>("Formule == \"Essentielle\"", ruleParameters);
+            Assert.True(resultEqual);
+        }
+
+        [Fact]
+        public void TestExpressionWithDictionaryParameter_MultipleKeys()
+        {
+            var parser = new RuleExpressionParser(new ReSettings());
+
+            var payload = new System.Collections.Generic.Dictionary<string, object>
+            {
+                { "Name", "John" },
+                { "Age", 30 }
+            };
+
+            var ruleParameters = new[] { RuleParameter.Create("input", payload) };
+
+            var result = parser.Evaluate<bool>("Name == \"John\" && Age == 30", ruleParameters);
+            Assert.True(result);
+        }
     }
 
     

--- a/test/RulesEngine.UnitTest/RulesEngine.UnitTest.csproj
+++ b/test/RulesEngine.UnitTest/RulesEngine.UnitTest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\signing\RulesEngine-publicKey.snk</AssemblyOriginatorKeyFile>
     <DelaySign>True</DelaySign>

--- a/test/RulesEngine.UnitTest/UtilsTests.cs
+++ b/test/RulesEngine.UnitTest/UtilsTests.cs
@@ -103,6 +103,120 @@ namespace RulesEngine.UnitTest
 
         }
 
+        [Fact]
+        public void GetTypedObject_Dictionary_ReturnsTypedObject()
+        {
+            var dict = new Dictionary<string, object>
+            {
+                { "Name", "Alice" },
+                { "Age", 25 }
+            };
+
+            var result = Utils.GetTypedObject(dict);
+            Assert.IsNotType<Dictionary<string, object>>(result);
+            Assert.NotNull(result.GetType().GetProperty("Name"));
+            Assert.NotNull(result.GetType().GetProperty("Age"));
+        }
+
+        [Fact]
+        public void GetTypedObject_Dictionary_NestedDictionary()
+        {
+            var dict = new Dictionary<string, object>
+            {
+                { "Name", "Alice" },
+                { "Address", new Dictionary<string, object>
+                    {
+                        { "City", "Seattle" },
+                        { "Zip", "98101" }
+                    }
+                }
+            };
+
+            var result = Utils.GetTypedObject(dict);
+            Assert.IsNotType<Dictionary<string, object>>(result);
+            var addressProp = result.GetType().GetProperty("Address");
+            Assert.NotNull(addressProp);
+            var address = addressProp.GetValue(result);
+            Assert.NotNull(address.GetType().GetProperty("City"));
+            Assert.NotNull(address.GetType().GetProperty("Zip"));
+        }
+
+        [Fact]
+        public void GetTypedObject_Dictionary_WithList()
+        {
+            var dict = new Dictionary<string, object>
+            {
+                { "Name", "Alice" },
+                { "Scores", new List<object> { 90, 85, 92 } }
+            };
+
+            var result = Utils.GetTypedObject(dict);
+            Assert.IsNotType<Dictionary<string, object>>(result);
+            Assert.NotNull(result.GetType().GetProperty("Name"));
+            Assert.NotNull(result.GetType().GetProperty("Scores"));
+        }
+
+        [Fact]
+        public void GetTypedObject_Dictionary_WithEmptyList()
+        {
+            var dict = new Dictionary<string, object>
+            {
+                { "Items", new List<object>() }
+            };
+
+            var result = Utils.GetTypedObject(dict);
+            Assert.IsNotType<Dictionary<string, object>>(result);
+            Assert.NotNull(result.GetType().GetProperty("Items"));
+        }
+
+        [Fact]
+        public void GetTypedObject_Dictionary_WithNestedExpandoObject()
+        {
+            dynamic nested = new ExpandoObject();
+            nested.Value = "test";
+
+            var dict = new Dictionary<string, object>
+            {
+                { "Nested", (object)nested }
+            };
+
+            var result = Utils.GetTypedObject(dict);
+            Assert.IsNotType<Dictionary<string, object>>(result);
+            var nestedProp = result.GetType().GetProperty("Nested");
+            Assert.NotNull(nestedProp);
+        }
+
+        [Fact]
+        public void GetTypedObject_Dictionary_WithListOfDictionaries()
+        {
+            var dict = new Dictionary<string, object>
+            {
+                { "People", new List<object>
+                    {
+                        new Dictionary<string, object> { { "Name", "Alice" } },
+                        new Dictionary<string, object> { { "Name", "Bob" } }
+                    }
+                }
+            };
+
+            var result = Utils.GetTypedObject(dict);
+            Assert.IsNotType<Dictionary<string, object>>(result);
+            Assert.NotNull(result.GetType().GetProperty("People"));
+        }
+
+        [Fact]
+        public void GetTypedObject_Dictionary_WithNullValue()
+        {
+            var dict = new Dictionary<string, object>
+            {
+                { "Name", "Alice" },
+                { "Middle", null }
+            };
+
+            var result = Utils.GetTypedObject(dict);
+            Assert.IsNotType<Dictionary<string, object>>(result);
+            Assert.NotNull(result.GetType().GetProperty("Name"));
+        }
 
     }
 }


### PR DESCRIPTION
## Summary

This PR adds support for .NET 10 and netstandard 2.1, and fixes a silent regression in 6.0.0 where `Dictionary<string, object>` keys were no longer resolved as named properties in rule expressions.

## Changes

### .NET 10 & netstandard 2.1 support
- Add `net10.0` and `netstandard2.1` to RulesEngine target frameworks
- Update `global.json` SDK to 10.0.100
- Add `net10.0` to test, demo, and benchmark projects
- Update conditional package references for `netstandard2.1`

### Fix: Dictionary<string, object> key resolution (#720)
- `Utils.GetTypedObject()` now converts `IDictionary<string, object>` to a strongly-typed dynamic class (same pattern as `ExpandoObject`)
- This restores correct behavior after the `System.Linq.Dynamic.Core` upgrade from 1.3.7 to 1.6.x which changed how dictionary keys are resolved

**Root cause:** The LINQ Dynamic library upgrade broke implicit property resolution on dictionary types. Only `ExpandoObject` was being wrapped into a dynamic class — `Dictionary<string, object>` passed through raw and keys were treated as string literals.

## Testing
- Added 2 new unit tests (`TestExpressionWithDictionaryParameter`, `TestExpressionWithDictionaryParameter_MultipleKeys`)
- All 121 existing tests pass on net10.0

Fixes #720