### PR TITLE
Fix #519, #576, #696 + regression guards for #590, #608, #581, #606

### DIFF
--- a/src/RulesEngine/Actions/ActionContext.cs
+++ b/src/RulesEngine/Actions/ActionContext.cs
@@ -17,22 +17,31 @@ namespace RulesEngine.Actions
         public ActionContext(IDictionary<string, object> context, RuleResultTree parentResult)
         {
             _context = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var kv in context)
+            if (context != null)
             {
-                string key = kv.Key;
-                string value;
-                switch (kv.Value.GetType().Name)
+                foreach (var kv in context)
                 {
-                    case "String":
-                    case "JsonElement":
-                        value =  kv.Value.ToString();
-                        break;
-                    default:
-                        value = JsonSerializer.Serialize(kv.Value);
-                        break;
-
+                    string key = kv.Key;
+                    string value;
+                    if (kv.Value == null)
+                    {
+                        value = null;
+                    }
+                    else
+                    {
+                        switch (kv.Value.GetType().Name)
+                        {
+                            case "String":
+                            case "JsonElement":
+                                value = kv.Value.ToString();
+                                break;
+                            default:
+                                value = JsonSerializer.Serialize(kv.Value);
+                                break;
+                        }
+                    }
+                    _context.Add(key, value);
                 }
-                _context.Add(key, value);
             }
             _parentResult = parentResult;
         }

--- a/src/RulesEngine/RulesEngine.cs
+++ b/src/RulesEngine/RulesEngine.cs
@@ -132,6 +132,9 @@ namespace RulesEngine
             var compiledRule = CompileRule(workflowName, ruleName, ruleParameters);
             var extendedRuleParameters = EvaluateGlobalsAdHoc(workflowName, ruleParameters);
             var resultTree = compiledRule(extendedRuleParameters);
+            // Mirror ExecuteAllRulesAsync's behavior: format the per-rule ErrorMessage template
+            // into ExceptionMessage before any action runs / before returning. See #519.
+            FormatErrorMessages(new[] { resultTree });
             var actionResult = await ExecuteActionForRuleResult(resultTree, true);
             ThrowIfActionExceptionShouldPropagate(actionResult, resultTree);
             return actionResult;
@@ -541,9 +544,7 @@ namespace RulesEngine
                             var property = paramVal?.Substring(2, paramVal.Length - 3);
                             if (property?.Split('.')?.Count() > 1)
                             {
-                                var typeName = property?.Split('.')?[0];
-                                var propertyName = property?.Split('.')?[1];
-                                errorMessage = UpdateErrorMessage(errorMessage, inputs, property, typeName, propertyName);
+                                errorMessage = UpdateErrorMessage(errorMessage, inputs, property);
                             }
                             else
                             {
@@ -562,28 +563,38 @@ namespace RulesEngine
         }
 
         /// <summary>
-        /// Updates the error message.
+        /// Resolves a dotted-path placeholder like $(input1.Inner.Name) against the rule inputs,
+        /// walking arbitrary depth. See #696.
         /// </summary>
-        /// <param name="errorMessage">The error message.</param>
-        /// <param name="evaluatedParams">The evaluated parameters.</param>
-        /// <param name="property">The property.</param>
-        /// <param name="typeName">Name of the type.</param>
-        /// <param name="propertyName">Name of the property.</param>
-        /// <returns>Updated error message.</returns>
-        private static string UpdateErrorMessage(string errorMessage, IDictionary<string, object> inputs, string property, string typeName, string propertyName)
+        private static string UpdateErrorMessage(string errorMessage, IDictionary<string, object> inputs, string property)
         {
-            var arrParams = inputs?.Select(c => new { Name = c.Key, c.Value });
-            var model = arrParams?.Where(a => string.Equals(a.Name, typeName))?.FirstOrDefault();
-            if (model != null)
+            var segments = property.Split('.');
+            var typeName = segments[0];
+            var model = inputs?.FirstOrDefault(c => string.Equals(c.Key, typeName));
+            if (model?.Value == null)
             {
-                var modelJson = JsonSerializer.Serialize(model?.Value);
-                var jObj = JsonObject.Parse(modelJson).AsObject();
-                JsonNode jToken = null;
-                var val = jObj?.TryGetPropertyValue(propertyName, out jToken);
-                errorMessage = errorMessage.Replace($"$({property})", jToken != null ? jToken?.ToString() : $"({property})");
+                return errorMessage;
             }
 
-            return errorMessage;
+            var modelJson = JsonSerializer.Serialize(model.Value.Value);
+            JsonNode current = JsonNode.Parse(modelJson);
+            for (var i = 1; i < segments.Length && current != null; i++)
+            {
+                current = current is JsonObject jObj && jObj.TryGetPropertyValue(segments[i], out var next)
+                    ? next
+                    : null;
+            }
+
+            if (current == null)
+            {
+                return errorMessage;
+            }
+
+            // JsonValue (leaf scalar) should render without quotes; objects/arrays render as JSON.
+            var replacement = current is JsonValue v && v.TryGetValue<string>(out var stringValue)
+                ? stringValue
+                : current.ToString();
+            return errorMessage.Replace($"$({property})", replacement);
         }
         #endregion
     }

--- a/test/RulesEngine.UnitTest/Issue519Test.cs
+++ b/test/RulesEngine.UnitTest/Issue519Test.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using RulesEngine.Models;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RulesEngine.UnitTest
+{
+    [ExcludeFromCodeCoverage]
+    public class Issue519Test
+    {
+        [Fact]
+        public async Task ExecuteActionWorkflowAsync_FailingRule_PopulatesExceptionMessageFromErrorMessage()
+        {
+            var workflow = new Workflow
+            {
+                WorkflowName = "wf",
+                Rules = new[] {
+                    new Rule {
+                        RuleName = "R",
+                        Expression = "input1 == \"expected\"",
+                        ErrorMessage = "Input was $(input1), expected `expected`"
+                    }
+                }
+            };
+            var engine = new RulesEngine(new[] { workflow });
+
+            var actionResult = await engine.ExecuteActionWorkflowAsync("wf", "R",
+                new[] { RuleParameter.Create("input1", "actual-value") });
+
+            var ruleResult = actionResult.Results.Single();
+            Assert.False(ruleResult.IsSuccess);
+            // Before the fix, ExceptionMessage was empty; after, it should contain the interpolated ErrorMessage.
+            Assert.False(string.IsNullOrEmpty(ruleResult.ExceptionMessage));
+            Assert.Contains("actual-value", ruleResult.ExceptionMessage);
+        }
+
+        [Fact]
+        public async Task ExecuteAllRulesAsync_BehavesTheSameForReference()
+        {
+            var workflow = new Workflow
+            {
+                WorkflowName = "wf",
+                Rules = new[] {
+                    new Rule {
+                        RuleName = "R",
+                        Expression = "input1 == \"expected\"",
+                        ErrorMessage = "Input was $(input1), expected `expected`"
+                    }
+                }
+            };
+            var engine = new RulesEngine(new[] { workflow });
+            var results = await engine.ExecuteAllRulesAsync("wf", "actual-value");
+
+            Assert.False(results[0].IsSuccess);
+            Assert.Contains("actual-value", results[0].ExceptionMessage);
+        }
+    }
+}

--- a/test/RulesEngine.UnitTest/Issue576Test.cs
+++ b/test/RulesEngine.UnitTest/Issue576Test.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using RulesEngine.Actions;
+using RulesEngine.Models;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RulesEngine.UnitTest
+{
+    [ExcludeFromCodeCoverage]
+    public class Issue576Test
+    {
+        private class NoContextAction : ActionBase
+        {
+            public static bool WasRun;
+            public override ValueTask<object> Run(ActionContext context, RuleParameter[] ruleParameters)
+            {
+                WasRun = true;
+                return new ValueTask<object>("done");
+            }
+        }
+
+        [Fact]
+        public async Task CustomAction_WithNullContext_DoesNotThrow()
+        {
+            NoContextAction.WasRun = false;
+
+            var workflow = new Workflow
+            {
+                WorkflowName = "wf",
+                Rules = new[] {
+                    new Rule {
+                        RuleName = "R",
+                        Expression = "true",
+                        Actions = new RuleActions {
+                            OnSuccess = new ActionInfo {
+                                Name = "noctx",
+                                Context = null
+                            }
+                        }
+                    }
+                }
+            };
+            var settings = new ReSettings
+            {
+                CustomActions = new Dictionary<string, Func<ActionBase>>
+                {
+                    { "noctx", () => new NoContextAction() }
+                }
+            };
+            var engine = new RulesEngine(new[] { workflow }, settings);
+            var results = await engine.ExecuteAllRulesAsync("wf", "x");
+
+            Assert.True(NoContextAction.WasRun, "Custom action should have run even with null Context");
+            Assert.Null(results[0].ActionResult?.Exception);
+        }
+
+        [Fact]
+        public void ActionContext_NullDictionary_DoesNotThrow()
+        {
+            var ex = Record.Exception(() => new ActionContext(null, null));
+            Assert.Null(ex);
+        }
+    }
+}

--- a/test/RulesEngine.UnitTest/Issue581Test.cs
+++ b/test/RulesEngine.UnitTest/Issue581Test.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using RulesEngine.Models;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RulesEngine.UnitTest
+{
+    [ExcludeFromCodeCoverage]
+    public class Issue581Support
+    {
+        public class MyParam
+        {
+            public string Value1 { get; set; }
+            public string Value2 { get; set; }
+        }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class Issue581Test
+    {
+        [Fact]
+        public async Task CustomParameterName_IsHonored()
+        {
+            var workflow = new Workflow
+            {
+                WorkflowName = "my_workflow",
+                Rules = new[] {
+                    new Rule {
+                        RuleName = "MatchesFabrikam",
+                        Enabled = true,
+                        RuleExpressionType = RuleExpressionType.LambdaExpression,
+                        Expression = "myValue.Value1 == \"Fabrikam\""
+                    }
+                }
+            };
+
+            var input = new Issue581Support.MyParam { Value1 = "Fabrikam", Value2 = "x" };
+            var rp = new RuleParameter("myValue", input);
+            var engine = new RulesEngine(new[] { workflow });
+
+            var results = await engine.ExecuteAllRulesAsync("my_workflow", new[] { rp });
+
+            Assert.True(results[0].IsSuccess,
+                $"Expected success. Got: {results[0].ExceptionMessage}");
+        }
+    }
+}

--- a/test/RulesEngine.UnitTest/Issue590Test.cs
+++ b/test/RulesEngine.UnitTest/Issue590Test.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using RulesEngine.Models;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RulesEngine.UnitTest
+{
+    [ExcludeFromCodeCoverage]
+    public class Issue590Test
+    {
+        public class FlakyInput
+        {
+            private int _counter;
+            private string _simpleProp;
+            public string SimpleProp
+            {
+                get
+                {
+                    if (_counter++ == 0)
+                    {
+                        throw new ArgumentException("first-call-failure");
+                    }
+                    return _simpleProp;
+                }
+                set { _simpleProp = value; }
+            }
+        }
+
+        [Fact]
+        public async Task ExceptionMessage_FromPriorRunDoesNotLeakIntoNextSuccessfulRun()
+        {
+            var input = new FlakyInput { SimpleProp = "simpleProp" };
+            var workflow = new Workflow
+            {
+                WorkflowName = "wf",
+                Rules = new[] {
+                    new Rule {
+                        RuleName = "CheckSimpleProp",
+                        RuleExpressionType = RuleExpressionType.LambdaExpression,
+                        Expression = "SimpleProp == \"simpleProp\"",
+                        ErrorMessage = "should not leak"
+                    }
+                }
+            };
+            var settings = new ReSettings { UseFastExpressionCompiler = false };
+            var engine = new RulesEngine(new[] { workflow }, settings);
+
+            var firstRun = await engine.ExecuteAllRulesAsync("wf", input);
+            Assert.False(firstRun[0].IsSuccess);
+            Assert.False(string.IsNullOrEmpty(firstRun[0].ExceptionMessage));
+
+            var secondRun = await engine.ExecuteAllRulesAsync("wf", input);
+            Assert.True(secondRun[0].IsSuccess,
+                $"Second run should succeed. Got ExceptionMessage = `{secondRun[0].ExceptionMessage}`");
+            Assert.True(string.IsNullOrEmpty(secondRun[0].ExceptionMessage),
+                $"Second run ExceptionMessage should be empty. Got `{secondRun[0].ExceptionMessage}`");
+        }
+    }
+}

--- a/test/RulesEngine.UnitTest/Issue606Test.cs
+++ b/test/RulesEngine.UnitTest/Issue606Test.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using RulesEngine.Models;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RulesEngine.UnitTest
+{
+    [ExcludeFromCodeCoverage]
+    public class Issue606Support
+    {
+        public class Line
+        {
+            public IReadOnlyList<string> Modifiers { get; set; } = new List<string>();
+        }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class Issue606Test
+    {
+        [Fact]
+        public async Task LambdaParameter_InAnyWithArrayLiteralContains_IsRecognized()
+        {
+            var workflow = new Workflow
+            {
+                WorkflowName = "wf",
+                Rules = new[] {
+                    new Rule {
+                        RuleName = "ContainsModifier",
+                        Expression = "line.Modifiers.Any(l => new [] {\"25\"}.Contains(l))"
+                    }
+                }
+            };
+            var input = new Issue606Support.Line { Modifiers = new List<string> { "25", "30" } };
+            var rp = new RuleParameter("line", input);
+
+            var engine = new RulesEngine(new[] { workflow });
+            var results = await engine.ExecuteAllRulesAsync("wf", new[] { rp });
+
+            Assert.True(results[0].IsSuccess,
+                $"Expected success. Got: {results[0].ExceptionMessage}");
+        }
+    }
+}

--- a/test/RulesEngine.UnitTest/Issue608Test.cs
+++ b/test/RulesEngine.UnitTest/Issue608Test.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using RulesEngine.Models;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RulesEngine.UnitTest
+{
+    [ExcludeFromCodeCoverage]
+    public class Issue608Support
+    {
+        public class AppData
+        {
+            public List<Detail> Details { get; set; } = new List<Detail>();
+        }
+        public class Detail
+        {
+            public decimal? Amount { get; set; }
+        }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class Issue608Test
+    {
+        private static Workflow BuildWorkflow() => new Workflow
+        {
+            WorkflowName = "wf",
+            Rules = new[] {
+                new Rule {
+                    RuleName = "ChainedSum",
+                    Expression = "Total > 0",
+                    LocalParams = new List<ScopedParam>
+                    {
+                        new ScopedParam { Name = "Field1", Expression = "AppData.Details.Sum(l => l.Amount)" },
+                        new ScopedParam { Name = "Field2", Expression = "AppData.Details.Sum(l => l.Amount)" },
+                        new ScopedParam { Name = "Field3", Expression = "AppData.Details.Sum(l => l.Amount)" },
+                        new ScopedParam { Name = "Total",  Expression = "Field1 + Field2 + Field3" }
+                    }
+                }
+            }
+        };
+
+        private static Issue608Support.AppData BuildInput() => new Issue608Support.AppData
+        {
+            Details = new List<Issue608Support.Detail>
+            {
+                new Issue608Support.Detail { Amount = 1 },
+                new Issue608Support.Detail { Amount = 2 },
+                new Issue608Support.Detail { Amount = 3 },
+            }
+        };
+
+        [Fact]
+        public async Task ChainedScopedParamSum_WithFastCompiler_Works()
+        {
+            var engine = new RulesEngine(new[] { BuildWorkflow() },
+                new ReSettings { UseFastExpressionCompiler = true });
+
+            var rp = new RuleParameter("AppData", BuildInput());
+            var results = await engine.ExecuteAllRulesAsync("wf", new[] { rp });
+
+            Assert.True(results[0].IsSuccess,
+                $"Expected success. Got: {results[0].ExceptionMessage}");
+        }
+
+        [Fact]
+        public async Task ChainedScopedParamSum_WithoutFastCompiler_StillWorks()
+        {
+            var engine = new RulesEngine(new[] { BuildWorkflow() },
+                new ReSettings { UseFastExpressionCompiler = false });
+
+            var rp = new RuleParameter("AppData", BuildInput());
+            var results = await engine.ExecuteAllRulesAsync("wf", new[] { rp });
+
+            Assert.True(results[0].IsSuccess);
+        }
+    }
+}

--- a/test/RulesEngine.UnitTest/Issue696Test.cs
+++ b/test/RulesEngine.UnitTest/Issue696Test.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using RulesEngine.Models;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RulesEngine.UnitTest
+{
+    [ExcludeFromCodeCoverage]
+    public class Issue696Support
+    {
+        public class Nested
+        {
+            public Inner Inner { get; set; }
+        }
+        public class Inner
+        {
+            public string Name { get; set; }
+        }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class Issue696Test
+    {
+        [Fact]
+        public async Task ErrorMessage_WithNestedDottedInterpolation_ResolvesRecursively()
+        {
+            var workflow = new Workflow
+            {
+                WorkflowName = "wf",
+                Rules = new[] {
+                    new Rule {
+                        RuleName = "R",
+                        Expression = "false",
+                        ErrorMessage = "got $(input1.Inner.Name)"
+                    }
+                }
+            };
+            var input = new Issue696Support.Nested
+            {
+                Inner = new Issue696Support.Inner { Name = "deep-value" }
+            };
+            var engine = new RulesEngine(new[] { workflow });
+            var results = await engine.ExecuteAllRulesAsync("wf",
+                new[] { RuleParameter.Create("input1", input) });
+
+            Assert.Equal("got deep-value", results[0].ExceptionMessage);
+        }
+
+        [Fact]
+        public async Task ErrorMessage_WithSingleLevelInterpolation_StillWorks()
+        {
+            // Regression guard for the existing one-level case.
+            var workflow = new Workflow
+            {
+                WorkflowName = "wf",
+                Rules = new[] {
+                    new Rule {
+                        RuleName = "R",
+                        Expression = "false",
+                        ErrorMessage = "got $(input1.Name)"
+                    }
+                }
+            };
+            var input = new Issue696Support.Inner { Name = "simple-value" };
+            var engine = new RulesEngine(new[] { workflow });
+            var results = await engine.ExecuteAllRulesAsync("wf",
+                new[] { RuleParameter.Create("input1", input) });
+
+            Assert.Contains("simple-value", results[0].ExceptionMessage);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Tier 2 follow-up to #727 (perf) and our batch-1 PR. Three real fixes, four already-fixed-on-main verifications turned into regression tests. Each fix has a dedicated test file.

## Fixes #576 — `ActionContext` ctor NRE when `Context` is null

`ActionContext`'s constructor unconditionally iterates `context` and dereferences each `kv.Value.GetType()`. Custom actions that don't need configuration commonly leave `OnSuccess.Context = null`, which crashed before the action could even run.

Added a null guard on the dictionary itself and on each value. A null value now stores `null` in the internal map instead of throwing.

## Fixes #519 — `ExecuteActionWorkflowAsync` skipped `FormatErrorMessages`

`ExecuteAllRulesAsync` interpolates `Rule.ErrorMessage` (`$(input.foo)`) into `RuleResultTree.ExceptionMessage` via `FormatErrorMessages`. `ExecuteActionWorkflowAsync` did not, so users got an unpopulated `ExceptionMessage` on the same workflow.

Added the call in `ExecuteActionWorkflowAsync` right before invoking the action. Result-tree shape and ordering are unchanged; only `ExceptionMessage` is now populated consistently.

## Fixes #696 — Multi-level dotted `ErrorMessage` interpolation

`UpdateErrorMessage` split the dotted path but only used segments `[0]` (typeName) and `[1]` (propertyName). For `$([input1.Inner.Name](https://nam06.safelinks.protection.outlook.com/?url=http%3A%2F%2Finput1.inner.name%2F&data=05%7C02%7CYogesh.Prajapati%40microsoft.com%7C8276de067a704d3c502608debc07dec3%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C639154939190866661%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=mjtWuqX8oJIvyRkxLPcQCYkCg8c2bh%2Ffv%2BzGl88fcNw%3D&reserved=0))` it set `typeName=input1`, `propertyName=Inner` — and then the replacement was the raw JSON of `Inner` (`{"Name":"deep-value"}`) instead of `"deep-value"`.

Rewrote the helper to walk the full path via `JsonNode`, returning the leaf scalar unquoted (for `JsonValue` strings) or nested JSON otherwise. The single-level case is unchanged.

## Regression guards (verified already fixed on master)

| # | Title | Fixed by |
|---|---|---|
| #590 | Exception message from prior run leaks into next successful run | Commit `4ca3cc2` (PR #592) |
| #608 | `UseFastExpressionCompiler=true` + chained scoped-param sums NRE'd | FastExpressionCompiler / Dynamic.Core version bumps |
| #581 | Custom parameter name not honored ("Enum type 'endpoint' not found") | Likely the `AutoRegisterInputType` work in PR #501 |
| #606 | Lambda parameter `l` reported as unknown identifier | Dynamic.Core 1.4.3 → 1.6.7 bumps |

Each repro from the linked issue now passes on master. Added explicit tests so we'd notice if any of these regressed.

## Not fixed in this PR

#390 (ActionContext receives literal string instead of evaluated value) is a design decision rather than a bug — `ActionContext` is documented as a static key/value config dict; users who want evaluation should use `OutputExpression`. Happy to revisit in a separate PR if the maintainers want to introduce a `$(...)`-evaluating mode.

## Test plan

- [x] 7 new test files (Issue519/576/581/590/606/608/696), 11 new tests total.
- [x] All 142 unit tests pass on net6.0 / net8.0 / net9.0 / net10.0.
- [x] No changes to public API surface; behavior changes only on the documented-but-broken paths.