### PR TITLE
CancellationToken (#609), AutoExecuteActions (#596), additionalInputs example (#573)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+- `IRulesEngine.ExecuteAllRulesAsync` gains an overload accepting a `CancellationToken`, observed cooperatively between rules and before each action. The existing `params object[]` and `params RuleParameter[]` overloads are unchanged; call-site overload resolution continues to pick them when no token is supplied (#609).
+- New `ReSettings.AutoExecuteActions` (default `true`). Set to `false` to evaluate rules without automatically running their OnSuccess/OnFailure actions, so callers can run actions selectively via `ExecuteActionWorkflowAsync` (#596).
+- Documented and tested passing computed `additionalInputs` into the `EvaluateRule` action — the additionalInput `Name` is referenced directly in the target rule's expression (#573).
+
 ## [6.0.1-preview.1]
 
 ### Performance

--- a/src/RulesEngine/Interfaces/IRulesEngine.cs
+++ b/src/RulesEngine/Interfaces/IRulesEngine.cs
@@ -3,6 +3,7 @@
 
 using RulesEngine.Models;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace RulesEngine.Interfaces
@@ -24,6 +25,16 @@ namespace RulesEngine.Interfaces
         /// <param name="ruleParams">A variable number of rule parameters</param>
         /// <returns>List of rule results</returns>
         ValueTask<List<RuleResultTree>> ExecuteAllRulesAsync(string workflowName, params RuleParameter[] ruleParams);
+
+        /// <summary>
+        /// This will execute all the rules of the specified workflow with cooperative cancellation.
+        /// </summary>
+        /// <param name="workflowName">The name of the workflow with rules to execute against the inputs</param>
+        /// <param name="ruleParams">The rule parameters</param>
+        /// <param name="cancellationToken">Token observed between rules and before each action</param>
+        /// <returns>List of rule results</returns>
+        ValueTask<List<RuleResultTree>> ExecuteAllRulesAsync(string workflowName, RuleParameter[] ruleParams, CancellationToken cancellationToken);
+
         ValueTask<ActionRuleResult> ExecuteActionWorkflowAsync(string workflowName, string ruleName, RuleParameter[] ruleParameters);
 
         /// <summary>

--- a/src/RulesEngine/Models/ReSettings.cs
+++ b/src/RulesEngine/Models/ReSettings.cs
@@ -29,6 +29,7 @@ namespace RulesEngine.Models
             AutoRegisterInputType = reSettings.AutoRegisterInputType;
             UseFastExpressionCompiler = reSettings.UseFastExpressionCompiler;
             EnableExceptionAsErrorMessageForRuleExpressionParsing = reSettings.EnableExceptionAsErrorMessageForRuleExpressionParsing;
+            AutoExecuteActions = reSettings.AutoExecuteActions;
         }
 
 
@@ -90,6 +91,13 @@ namespace RulesEngine.Models
         /// Default: true
         /// </summary>
         public bool EnableExceptionAsErrorMessageForRuleExpressionParsing { get; set; } = true;
+
+        /// <summary>
+        /// When true (default), ExecuteAllRulesAsync automatically runs each matched rule's
+        /// OnSuccess/OnFailure action after evaluation. Set to false to evaluate rules only and
+        /// run actions yourself (e.g. via ExecuteActionWorkflowAsync) for selective control. See #596.
+        /// </summary>
+        public bool AutoExecuteActions { get; set; } = true;
     }
 
     public enum NestedRuleExecutionMode

--- a/src/RulesEngine/RulesEngine.cs
+++ b/src/RulesEngine/RulesEngine.cs
@@ -14,6 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace RulesEngine
@@ -103,20 +104,38 @@ namespace RulesEngine
         /// <returns>List of rule results</returns>
         public async ValueTask<List<RuleResultTree>> ExecuteAllRulesAsync(string workflowName, params RuleParameter[] ruleParams)
         {
+            return await ExecuteAllRulesAsync(workflowName, ruleParams, default);
+        }
+
+        /// <summary>
+        /// This will execute all the rules of the specified workflow with cooperative cancellation.
+        /// </summary>
+        /// <param name="workflowName">The name of the workflow with rules to execute against the inputs</param>
+        /// <param name="ruleParams">The rule parameters</param>
+        /// <param name="cancellationToken">Token observed between rules and before each action. A single
+        /// rule's compiled expression is not interrupted mid-evaluation; cancellation is cooperative at
+        /// rule and action boundaries.</param>
+        /// <returns>List of rule results</returns>
+        public async ValueTask<List<RuleResultTree>> ExecuteAllRulesAsync(string workflowName, RuleParameter[] ruleParams, CancellationToken cancellationToken)
+        {
             var sortedRuleParams = ruleParams.ToList();
             sortedRuleParams.Sort((RuleParameter a, RuleParameter b) => string.Compare(a.Name, b.Name));
-            var ruleResultList = ValidateWorkflowAndExecuteRule(workflowName, sortedRuleParams.ToArray());
-            await ExecuteActionAsync(ruleResultList);
+            var ruleResultList = ValidateWorkflowAndExecuteRule(workflowName, sortedRuleParams.ToArray(), cancellationToken);
+            if (_reSettings.AutoExecuteActions)
+            {
+                await ExecuteActionAsync(ruleResultList, cancellationToken);
+            }
             return ruleResultList;
         }
 
-        private async ValueTask ExecuteActionAsync(IEnumerable<RuleResultTree> ruleResultList)
+        private async ValueTask ExecuteActionAsync(IEnumerable<RuleResultTree> ruleResultList, CancellationToken cancellationToken = default)
         {
             foreach (var ruleResult in ruleResultList)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 if(ruleResult.ChildResults !=  null)
                 {
-                    await ExecuteActionAsync(ruleResult.ChildResults);
+                    await ExecuteActionAsync(ruleResult.ChildResults, cancellationToken);
                 }
                 var actionResult = await ExecuteActionForRuleResult(ruleResult, false);
                 ruleResult.ActionResult = new ActionResult {
@@ -304,13 +323,13 @@ namespace RulesEngine
         /// <param name="input">input</param>
         /// <param name="workflowName">workflow name</param>
         /// <returns>list of rule result set</returns>
-        private List<RuleResultTree> ValidateWorkflowAndExecuteRule(string workflowName, RuleParameter[] ruleParams)
+        private List<RuleResultTree> ValidateWorkflowAndExecuteRule(string workflowName, RuleParameter[] ruleParams, CancellationToken cancellationToken = default)
         {
             List<RuleResultTree> result;
 
             if (RegisterRule(workflowName, ruleParams))
             {
-                result = ExecuteAllRuleByWorkflow(workflowName, ruleParams);
+                result = ExecuteAllRuleByWorkflow(workflowName, ruleParams, cancellationToken);
             }
             else
             {
@@ -430,7 +449,7 @@ namespace RulesEngine
         /// <param name="workflowName"></param>
         /// <param name="ruleParams"></param>
         /// <returns>list of rule result set</returns>
-        private List<RuleResultTree> ExecuteAllRuleByWorkflow(string workflowName, RuleParameter[] ruleParameters)
+        private List<RuleResultTree> ExecuteAllRuleByWorkflow(string workflowName, RuleParameter[] ruleParameters, CancellationToken cancellationToken = default)
         {
             var result = new List<RuleResultTree>();
             var compiledRulesCacheKey = GetCompiledRulesKey(workflowName, ruleParameters);
@@ -456,6 +475,7 @@ namespace RulesEngine
 
             foreach (var compiledRule in compiledRules)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 RuleResultTree resultTree;
                 if (globalEvaluationException != null && ruleByName != null && ruleByName.TryGetValue(compiledRule.Key, out var rule))
                 {

--- a/test/RulesEngine.UnitTest/Issue573Test.cs
+++ b/test/RulesEngine.UnitTest/Issue573Test.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using RulesEngine.Models;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RulesEngine.UnitTest
+{
+    [ExcludeFromCodeCoverage]
+    public class Issue573Test
+    {
+        // Demonstrates the correct way to pass computed additionalInputs into an EvaluateRule
+        // action. The target rule can reference the additionalInput by its Name. The key detail
+        // (the source of the "Unknown identifier" confusion in #573) is that the additionalInput
+        // Name must match the identifier used in the target rule's expression.
+        [Fact]
+        public async Task EvaluateRuleAction_AdditionalInputs_AreAvailableToTargetRule()
+        {
+            var workflow = new Workflow
+            {
+                WorkflowName = "wf",
+                Rules = new[]
+                {
+                    new Rule
+                    {
+                        RuleName = "Parent",
+                        Expression = "input1.Value > 0",
+                        Actions = new RuleActions
+                        {
+                            OnSuccess = new ActionInfo
+                            {
+                                Name = "EvaluateRule",
+                                Context = new Dictionary<string, object>
+                                {
+                                    { "workflowName", "wf" },
+                                    { "ruleName", "Child" },
+                                    // Compute a new input named "doubled" from input1 and pass it on.
+                                    { "additionalInputs", new List<ScopedParam>
+                                        {
+                                            new ScopedParam { Name = "doubled", Expression = "input1.Value * 2" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    new Rule
+                    {
+                        RuleName = "Child",
+                        // References the additionalInput by name.
+                        Expression = "doubled == 20"
+                    }
+                }
+            };
+
+            var engine = new RulesEngine(new[] { workflow });
+            var result = await engine.ExecuteActionWorkflowAsync("wf", "Parent",
+                new[] { RuleParameter.Create("input1", new { Value = 10 }) });
+
+            // Child rule succeeded because "doubled" (10*2=20) was available to it.
+            Assert.NotNull(result.Results);
+            Assert.Contains(result.Results, r => r.Rule.RuleName == "Child" && r.IsSuccess);
+        }
+    }
+}

--- a/test/RulesEngine.UnitTest/Issue596Test.cs
+++ b/test/RulesEngine.UnitTest/Issue596Test.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using RulesEngine.Actions;
+using RulesEngine.Models;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RulesEngine.UnitTest
+{
+    [ExcludeFromCodeCoverage]
+    public class Issue596Test
+    {
+        private class CountingAction : ActionBase
+        {
+            public static int RunCount;
+            public override ValueTask<object> Run(ActionContext context, RuleParameter[] ruleParameters)
+            {
+                Interlocked.Increment(ref RunCount);
+                return new ValueTask<object>("done");
+            }
+        }
+
+        private static Workflow WorkflowWithAction() => new Workflow
+        {
+            WorkflowName = "wf",
+            Rules = new[] {
+                new Rule {
+                    RuleName = "R",
+                    Expression = "true",
+                    Actions = new RuleActions {
+                        OnSuccess = new ActionInfo { Name = "counting", Context = new Dictionary<string, object>() }
+                    }
+                }
+            }
+        };
+
+        [Fact]
+        public async Task AutoExecuteActions_True_RunsActions_DefaultBehavior()
+        {
+            CountingAction.RunCount = 0;
+            var settings = new ReSettings
+            {
+                CustomActions = new Dictionary<string, Func<ActionBase>> { { "counting", () => new CountingAction() } }
+            };
+            var engine = new RulesEngine(new[] { WorkflowWithAction() }, settings);
+
+            var results = await engine.ExecuteAllRulesAsync("wf", "x");
+
+            Assert.True(results[0].IsSuccess);
+            Assert.Equal(1, CountingAction.RunCount);
+        }
+
+        [Fact]
+        public async Task AutoExecuteActions_False_EvaluatesRulesButSkipsActions()
+        {
+            CountingAction.RunCount = 0;
+            var settings = new ReSettings
+            {
+                AutoExecuteActions = false,
+                CustomActions = new Dictionary<string, Func<ActionBase>> { { "counting", () => new CountingAction() } }
+            };
+            var engine = new RulesEngine(new[] { WorkflowWithAction() }, settings);
+
+            var results = await engine.ExecuteAllRulesAsync("wf", "x");
+
+            // Rule still evaluated...
+            Assert.True(results[0].IsSuccess);
+            // ...but the action did NOT run automatically.
+            Assert.Equal(0, CountingAction.RunCount);
+
+            // Caller can still run the action selectively afterwards.
+            var actionResult = await engine.ExecuteActionWorkflowAsync("wf", "R", new RuleParameter[0]);
+            Assert.Equal("done", actionResult.Output);
+            Assert.Equal(1, CountingAction.RunCount);
+        }
+    }
+}

--- a/test/RulesEngine.UnitTest/Issue609Test.cs
+++ b/test/RulesEngine.UnitTest/Issue609Test.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using RulesEngine.Models;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RulesEngine.UnitTest
+{
+    [ExcludeFromCodeCoverage]
+    public class Issue609Test
+    {
+        private static Workflow ManyRulesWorkflow(int count) => new Workflow
+        {
+            WorkflowName = "wf",
+            Rules = Enumerable.Range(0, count)
+                .Select(i => new Rule { RuleName = $"R{i}", Expression = "input1 >= 0" })
+                .ToArray()
+        };
+
+        [Fact]
+        public async Task ExecuteAllRulesAsync_WithUncancelledToken_RunsNormally()
+        {
+            var engine = new RulesEngine(new[] { ManyRulesWorkflow(5) });
+            var results = await engine.ExecuteAllRulesAsync(
+                "wf", new[] { RuleParameter.Create("input1", 1) }, CancellationToken.None);
+            Assert.Equal(5, results.Count);
+            Assert.All(results, r => Assert.True(r.IsSuccess));
+        }
+
+        [Fact]
+        public async Task ExecuteAllRulesAsync_WithAlreadyCancelledToken_Throws()
+        {
+            var engine = new RulesEngine(new[] { ManyRulesWorkflow(5) });
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+                await engine.ExecuteAllRulesAsync(
+                    "wf", new[] { RuleParameter.Create("input1", 1) }, cts.Token));
+        }
+
+        [Fact]
+        public async Task ExecuteAllRulesAsync_DefaultOverloads_StillWork_NoBehavioralBreakage()
+        {
+            // The pre-existing signatures still resolve correctly. The new 3-arg overload is
+            // strictly more specific than `params object[]`, so call sites that pass
+            // (string, array) continue to bind to the params overloads as before.
+            var engine = new RulesEngine(new[] { ManyRulesWorkflow(3) });
+            var byParams = await engine.ExecuteAllRulesAsync("wf", 1);
+            var byRuleParams = await engine.ExecuteAllRulesAsync("wf", new[] { RuleParameter.Create("input1", 1) });
+            Assert.Equal(3, byParams.Count);
+            Assert.Equal(3, byRuleParams.Count);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Three Tier-4 feature requests that met the bar of being **generic, well-justified, and implementable without breaking changes**. Each is additive; default behavior is unchanged.

### #609 — `CancellationToken` support on `ExecuteAllRulesAsync`

New overload `ExecuteAllRulesAsync(string workflowName, RuleParameter[] ruleParams, CancellationToken cancellationToken)`. The token is observed cooperatively — checked between rules (`ExecuteAllRuleByWorkflow`) and before each action (`ExecuteActionAsync`). A single rule's compiled expression isn't interrupted mid-evaluation (they're fast synchronous delegates); cancellation happens at rule/action boundaries, which is where async action work lives.

Added to `IRulesEngine` as well, per the repo's `Class_PublicMethods_ArePartOfInterface` invariant. **Source-compatible for all callers** — the existing `params object[]` and `params RuleParameter[]` overloads are untouched; only someone who *implements* `IRulesEngine` themselves would need to add the member (the same is true of every prior API addition in this library).

### #596 — `ReSettings.AutoExecuteActions` (default `true`)

When `false`, `ExecuteAllRulesAsync` evaluates rules but **skips** the automatic OnSuccess/OnFailure action execution, letting callers run actions selectively (the issue's use case: send only the first matched rule's decision to an external API) via `ExecuteActionWorkflowAsync`. Default `true` preserves current behavior exactly. Wired into the `ReSettings` copy constructor so it round-trips.

### #573 — `additionalInputs` for `EvaluateRule` action (already supported; documented + tested)

`EvaluateRuleAction` already evaluates `additionalInputs` and adds them as rule parameters — the reporter just lacked a working example and hit "Unknown identifier". Added a test showing a computed input (`"doubled"` = `input1.Value * 2`) referenced **by its `Name`** in the target rule's expression. No code change; this lets the issue close with a concrete example.

## Deferred (with reasons)

| # | Request | Why not now |
|---|---|---|
| #623 | Optional method parameters | `System.Linq.Dynamic.Core` method-resolution limitation; not fixable in RulesEngine without forking the parser |
| #598 | Implicit property access on lists (`Users.Name`) | Non-standard semantics (not valid C# either); `Users.Any(u => u.Name==…)` already works |
| #565 | SequentialAnd / SequentialOr operators | Already achievable: `AndAlso`/`OrElse` + `NestedRuleExecutionMode.Performance` short-circuits identically |
| #569 | Multiple success/fail actions | Requires a workflow-schema change (`OnSuccess` → list); needs maintainer buy-in on API shape |
| #564 | Access RulesEngine inside custom Action | Niche; reentrancy concerns; workaround = inject deps via custom action factory |
| #550 | Bypass rule eval, run action only | Niche cross-process scenario, not generic |

## Test plan

- [x] 3 new test files (`Issue609Test`, `Issue596Test`, `Issue573Test`) — 6 new tests covering happy path, cancellation (uncancelled + pre-cancelled), non-breaking signature checks, action-skip + selective-run, and the additionalInputs example.
- [x] All **161** unit tests pass on net6.0 / net8.0 / net9.0 / net10.0.
- [x] `Class_PublicMethods_ArePartOfInterface` passes (interface kept in sync).
- [x] CHANGELOG `[Unreleased]` section updated.
