### PR TITLE
Release 6.0.1-preview.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [6.0.1-preview.2]
+
 ### Features
 - `IRulesEngine.ExecuteAllRulesAsync` gains an overload accepting a `CancellationToken`, observed cooperatively between rules and before each action. The existing `params object[]` and `params RuleParameter[]` overloads are unchanged; call-site overload resolution continues to pick them when no token is supplied (#609).
 - New `ReSettings.AutoExecuteActions` (default `true`). Set to `false` to evaluate rules without automatically running their OnSuccess/OnFailure actions, so callers can run actions selectively via `ExecuteActionWorkflowAsync` (#596).

--- a/src/RulesEngine/RulesEngine.csproj
+++ b/src/RulesEngine/RulesEngine.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net8.0;net9.0;net10.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>13.0</LangVersion>
-    <Version>6.0.1-preview.1</Version>
+    <Version>6.0.1-preview.2</Version>
     <Copyright>Copyright (c) Microsoft Corporation.</Copyright>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/microsoft/RulesEngine</PackageProjectUrl>


### PR DESCRIPTION
Bump <Version> from 6.0.1-preview.1 to 6.0.1-preview.2 and add a CHANGELOG entry covering the PRs landed since 6.0.1-preview.1.