### PR TITLE
Fix warmup regression: avoid per-expression AppDomain assembly scan (fixes #739)

### DIFF
--- a/src/RulesEngine/CustomTypeProvider.cs
+++ b/src/RulesEngine/CustomTypeProvider.cs
@@ -42,11 +42,19 @@ namespace RulesEngine
             _types.Add(typeof(IEnumerable));
         }
 
+        private HashSet<Type> _mergedTypes;
+
         public override HashSet<Type> GetCustomTypes()
         {
-            var all = new HashSet<Type>(base.GetCustomTypes());
-            all.UnionWith(_types);
-            return all;
+            // base.GetCustomTypes() scans every assembly in the AppDomain for [DynamicLinqType].
+            // The provider's type set is fixed after construction, so merge exactly once.
+            if (_mergedTypes == null)
+            {
+                var all = new HashSet<Type>(base.GetCustomTypes());
+                all.UnionWith(_types);
+                _mergedTypes = all;
+            }
+            return _mergedTypes;
         }
     }
 }

--- a/src/RulesEngine/ExpressionBuilders/RuleExpressionParser.cs
+++ b/src/RulesEngine/ExpressionBuilders/RuleExpressionParser.cs
@@ -83,12 +83,33 @@ namespace RulesEngine.ExpressionBuilders
             _methodInfo.Add("dict_add", dict_add);
         }
 
+        private ParsingConfig _cachedParsingConfig;
+        private Type[] _cachedParsingConfigCustomTypes;
+
+        private ParsingConfig GetParsingConfig()
+        {
+            // Building a CustomTypeProvider is expensive: System.Linq.Dynamic.Core's
+            // DefaultDynamicLinqCustomTypeProvider scans all AppDomain assemblies for
+            // [DynamicLinqType] and only caches per provider instance. Reuse one config
+            // until ReSettings.CustomTypes is swapped (AutoRegisterInputType does this
+            // on workflow registration).
+            var customTypes = _reSettings.CustomTypes;
+            var config = _cachedParsingConfig;
+            if (config == null || !ReferenceEquals(_cachedParsingConfigCustomTypes, customTypes))
+            {
+                config = new ParsingConfig {
+                    CustomTypeProvider = new CustomTypeProvider(customTypes),
+                    IsCaseSensitive = _reSettings.IsExpressionCaseSensitive
+                };
+                _cachedParsingConfigCustomTypes = customTypes;
+                _cachedParsingConfig = config;
+            }
+            return config;
+        }
+
         public Expression Parse(string expression, ParameterExpression[] parameters, Type returnType)
         {
-            var config = new ParsingConfig {
-                CustomTypeProvider = new CustomTypeProvider(_reSettings.CustomTypes),
-                IsCaseSensitive = _reSettings.IsExpressionCaseSensitive
-            };
+            var config = GetParsingConfig();
 
             // Instead of immediately returning default values, allow for expression parsing to handle dynamic evaluation.
             try


### PR DESCRIPTION
## Problem

Since 71d59dc (#675), `CustomTypeProvider.GetCustomTypes()` includes `base.GetCustomTypes()`, which scans every AppDomain assembly for `[DynamicLinqType]` types. System.Linq.Dynamic.Core caches that scan only per provider instance, and `RuleExpressionParser.Parse` builds a new `ParsingConfig` + `CustomTypeProvider` for every expression parsed (Dynamic LINQ's `KeywordsHelper` enumerates the full type set on each `ExpressionParser` construction). The result is one full assembly scan per expression, per rule.

For large workflows this regressed warmup ~6.6x vs 5.0.3 (113.8 s vs 17.3 s for 20,000 rules with local params and 174 loaded assemblies). The compiled-delegate cache from #727 does not help because each rule expression is unique. This is the remaining root cause behind #707.

## Change

- `RuleExpressionParser`: reuse one `ParsingConfig`/`CustomTypeProvider` across parses; rebuild only when `ReSettings.CustomTypes` is swapped (`AutoRegisterInputType` replaces the array on workflow registration), preserving the behavior introduced by #675.
- `CustomTypeProvider`: memoize the merged custom-type set; it is fixed after construction but was rebuilt — including the assembly scan — on every `GetCustomTypes()` call.

## Results

Same 20,000-rule benchmark: **113.8 s → 16.3 s**, matching 5.0.3, with identical rule results.

All 170 existing unit tests pass. No public API change.