### PR TITLE
Validate duplicate param names and input/global collisions with clear errors

### DIFF
--- a/src/RulesEngine/HelperFunctions/Constants.cs
+++ b/src/RulesEngine/HelperFunctions/Constants.cs
@@ -21,6 +21,9 @@ namespace RulesEngine.HelperFunctions
         public const string LAMBDA_EXPRESSION_EXPRESSION_NULL_ERRMSG = "Expression cannot be null or empty when RuleExpressionType is LambdaExpression";
         public const string LAMBDA_EXPRESSION_OPERATOR_ERRMSG = "Cannot use Operator field when RuleExpressionType is LambdaExpression";
         public const string LAMBDA_EXPRESSION_RULES_ERRMSG = "Cannot use Rules field when RuleExpressionType is LambdaExpression";
+        public const string DUPLICATE_GLOBAL_PARAM_NAME_ERRMSG = "Duplicate GlobalParam name '{0}'. GlobalParam names must be unique within a workflow.";
+        public const string DUPLICATE_LOCAL_PARAM_NAME_ERRMSG = "Duplicate LocalParam name '{0}'. LocalParam names must be unique within a rule.";
+        public const string GLOBAL_PARAM_INPUT_COLLISION_ERRMSG = "GlobalParam name '{0}' collides with an input RuleParameter of the same name. Rename either the global or the input to disambiguate.";
 
     }
 }

--- a/src/RulesEngine/RulesEngine.cs
+++ b/src/RulesEngine/RulesEngine.cs
@@ -186,6 +186,18 @@ namespace RulesEngine
             }
             var inputs = ruleParameters.Select(c => c.Value).ToArray();
             var evaluated = globalParamsDelegate(inputs);
+
+            // Catch input/global name collisions here with a clear error instead of letting
+            // Helpers.ToResultTree's ToDictionary throw the cryptic "key already added" message.
+            var inputNames = new HashSet<string>(ruleParameters.Select(c => c.Name), StringComparer.Ordinal);
+            foreach (var key in evaluated.Keys)
+            {
+                if (inputNames.Contains(key))
+                {
+                    throw new RuleException(string.Format(Constants.GLOBAL_PARAM_INPUT_COLLISION_ERRMSG, key));
+                }
+            }
+
             var globals = evaluated.Select(kv => new RuleParameter(kv.Key, kv.Value));
             return ruleParameters.Concat(globals).ToArray();
         }

--- a/src/RulesEngine/Validators/RuleValidator.cs
+++ b/src/RulesEngine/Validators/RuleValidator.cs
@@ -33,6 +33,14 @@ namespace RulesEngine.Validators
                 });
             });
             RegisterExpressionTypeRules();
+
+            // Surface duplicate LocalParam names with a clear message instead of a cryptic
+            // "An item with the same key has already been added" failure later at execution.
+            RuleFor(c => c)
+                .Must(rule => WorkflowsValidator.FindDuplicateName(rule.LocalParams?.Select(p => p?.Name)) == null)
+                .WithMessage(rule => string.Format(
+                    Constants.DUPLICATE_LOCAL_PARAM_NAME_ERRMSG,
+                    WorkflowsValidator.FindDuplicateName(rule.LocalParams?.Select(p => p?.Name))));
         }
 
         private void RegisterExpressionTypeRules()

--- a/src/RulesEngine/Validators/WorkflowRulesValidator.cs
+++ b/src/RulesEngine/Validators/WorkflowRulesValidator.cs
@@ -19,6 +19,26 @@ namespace RulesEngine.Validators
                 var ruleValidator = new RuleValidator();
                 RuleForEach(c => c.Rules).SetValidator(ruleValidator);
             });
+
+            // Surface duplicate GlobalParam names with a clear message instead of a cryptic
+            // "An item with the same key has already been added" failure later at execution.
+            RuleFor(c => c)
+                .Must(workflow => FindDuplicateName(workflow.GlobalParams?.Select(p => p?.Name)) == null)
+                .WithMessage(workflow => string.Format(
+                    Constants.DUPLICATE_GLOBAL_PARAM_NAME_ERRMSG,
+                    FindDuplicateName(workflow.GlobalParams?.Select(p => p?.Name))));
+        }
+
+        internal static string FindDuplicateName(System.Collections.Generic.IEnumerable<string> names)
+        {
+            if (names == null) return null;
+            var seen = new System.Collections.Generic.HashSet<string>(System.StringComparer.Ordinal);
+            foreach (var name in names)
+            {
+                if (string.IsNullOrEmpty(name)) continue;
+                if (!seen.Add(name)) return name;
+            }
+            return null;
         }
     }
 }

--- a/test/RulesEngine.UnitTest/DuplicateParamNameValidationTest.cs
+++ b/test/RulesEngine.UnitTest/DuplicateParamNameValidationTest.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using RulesEngine.Exceptions;
+using RulesEngine.Models;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RulesEngine.UnitTest
+{
+    [ExcludeFromCodeCoverage]
+    public class DuplicateParamNameValidationTest
+    {
+        // Two GlobalParams with the same Name in the same workflow used to crash deep inside
+        // RuleResultTree construction with "An item with the same key has already been added.
+        // Key: dup". This change validates the workflow at AddWorkflow time and surfaces a clear
+        // error pointing at the offending name.
+        [Fact]
+        public void AddWorkflow_DuplicateGlobalParamNames_ThrowsClearValidationError()
+        {
+            var workflow = new Workflow
+            {
+                WorkflowName = "wf",
+                GlobalParams = new[]
+                {
+                    new ScopedParam { Name = "dup", Expression = "1" },
+                    new ScopedParam { Name = "dup", Expression = "2" }
+                },
+                Rules = new[] { new Rule { RuleName = "R", Expression = "dup == 1" } }
+            };
+
+            var engine = new RulesEngine();
+            var ex = Assert.Throws<RuleValidationException>(() => engine.AddWorkflow(workflow));
+            Assert.Contains("dup", ex.Message);
+            Assert.Contains("duplicate", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void AddWorkflow_DuplicateLocalParamNames_ThrowsClearValidationError()
+        {
+            // Same protection for per-rule LocalParams.
+            var workflow = new Workflow
+            {
+                WorkflowName = "wf",
+                Rules = new[] {
+                    new Rule {
+                        RuleName = "R",
+                        Expression = "dup == 1",
+                        LocalParams = new[]
+                        {
+                            new ScopedParam { Name = "dup", Expression = "1" },
+                            new ScopedParam { Name = "dup", Expression = "2" }
+                        }
+                    }
+                }
+            };
+
+            var engine = new RulesEngine();
+            var ex = Assert.Throws<RuleValidationException>(() => engine.AddWorkflow(workflow));
+            Assert.Contains("dup", ex.Message);
+            Assert.Contains("duplicate", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // A caller-supplied RuleParameter whose Name collides with a workflow GlobalParam's Name
+        // used to surface as a cryptic "An item with the same key has already been added" deep
+        // inside result-tree construction. After this change the per-rule ExceptionMessage
+        // explicitly names the colliding identifier — same surfacing pattern as other
+        // scoped-params errors that ExecuteAllRuleByWorkflow already catches and reports per rule.
+        [Fact]
+        public async Task ExecuteAllRulesAsync_CallerInputCollidesWithGlobalParam_SurfacesClearCollisionError()
+        {
+            var workflow = new Workflow
+            {
+                WorkflowName = "wf",
+                GlobalParams = new[]
+                {
+                    new ScopedParam { Name = "foo", Expression = "99" }
+                },
+                Rules = new[] { new Rule { RuleName = "R", Expression = "foo == 99" } }
+            };
+            var engine = new RulesEngine(new[] { workflow });
+
+            var results = await engine.ExecuteAllRulesAsync("wf",
+                new[] { RuleParameter.Create("foo", 42) });
+
+            Assert.False(results[0].IsSuccess);
+            Assert.Contains("foo", results[0].ExceptionMessage);
+            Assert.Contains("collide", results[0].ExceptionMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("same key has already been added", results[0].ExceptionMessage);
+        }
+
+        // Sanity: no collision when names are distinct (regression guard for the validation logic).
+        [Fact]
+        public async Task ExecuteAllRulesAsync_DistinctNames_StillWorks()
+        {
+            var workflow = new Workflow
+            {
+                WorkflowName = "wf",
+                GlobalParams = new[]
+                {
+                    new ScopedParam { Name = "fromGlobal", Expression = "99" }
+                },
+                Rules = new[] { new Rule { RuleName = "R", Expression = "fromInput == 42 && fromGlobal == 99" } }
+            };
+            var engine = new RulesEngine(new[] { workflow });
+
+            var results = await engine.ExecuteAllRulesAsync("wf",
+                new[] { RuleParameter.Create("fromInput", 42) });
+
+            Assert.True(results[0].IsSuccess);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Cleans up three cryptic "An item with the same key has already been added. Key: …" failures users hit when they accidentally introduce a name collision. Surfaced while triaging stale PR #402 — the underlying concerns it identified are real bugs even though that PR's proposed approach wasn't a fit.

## The three cases

| Case | When | Was | Now |
|---|---|---|---|
| Two `GlobalParams` in the same workflow with the same `Name` | Detected at `AddWorkflow` if eagerly used; otherwise at execution | `Dictionary.ToDictionary` throws `"An item with the same key has already been added. Key: dup"` | `WorkflowsValidator` throws `RuleValidationException("Duplicate GlobalParam name 'dup'. GlobalParam names must be unique within a workflow.")` |
| Two `LocalParams` on the same rule with the same `Name` | Same | Same cryptic error | `RuleValidator` throws `RuleValidationException("Duplicate LocalParam name 'dup'. …")` |
| Caller passes `RuleParameter("foo", …)` against a workflow with `GlobalParam("foo", …)` | At execution | Same cryptic error from result-tree construction | `RulesEngine.AppendGlobals` throws `RuleException("GlobalParam name 'foo' collides with an input RuleParameter of the same name. Rename either the global or the input to disambiguate.")` — flowed through the existing per-rule error-surfacing path so each rule's `ExceptionMessage` carries the explanation |

## Why this shape

- **Compile-time validation for duplicate workflow definitions** (cases 1 and 2) — these are author errors and should be caught when the workflow is loaded, before execution starts. Fits cleanly into the existing FluentValidation pipeline (`WorkflowsValidator` / `RuleValidator`).
- **Run-time check for input/global collisions** (case 3) — can only be detected when caller inputs are known. The check lives where the values are actually merged (`AppendGlobals`) and uses the same `try`/`catch` surfacing pattern other scoped-params errors already use in `ExecuteAllRuleByWorkflow`, so the behavior is consistent: each rule's `ExceptionMessage` explains the collision and `IsSuccess = false`.
- Messages live in `HelperFunctions/Constants.cs` alongside the existing validator strings — same convention.

## Not in this PR

The other claims in PR #402 either don't reproduce on current `main` (Dynamic.Core `new (…)` syntax works without `AllowNewToEvaluateAnyType`) or are design debates rather than bugs (chained-rule result visibility, PostActions timing).

## Test plan

- [x] New test file `DuplicateParamNameValidationTest.cs` covering:
  - Duplicate `GlobalParams` → `RuleValidationException` with "duplicate" + offending name
  - Duplicate `LocalParams` → same
  - Caller input collides with global → per-rule `ExceptionMessage` contains "collide" + offending name; does NOT contain "same key has already been added"
  - Distinct names → still execute successfully (regression guard)
- [x] All **174** unit tests pass on net6.0 / net8.0 / net9.0 / net10.0
- [x] No public API surface change; behavior change is **strictly more helpful errors on previously failing inputs**